### PR TITLE
feat: TypeScript migration + linting pipeline

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,6 +21,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm run lint
+      - run: npm run format:check
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.swo
 *~
 .vscode/
+node_modules/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "semi": true
+}

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,7 @@
+{
+  "extends": "stylelint-config-standard",
+  "rules": {
+    "declaration-block-no-duplicate-properties": true,
+    "no-descending-specificity": null
+  }
+}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -6,31 +6,34 @@
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,500;0,600;1,400&display=swap');
 
 :root {
-  --bg:        #0a0e0a;
+  --bg: #0a0e0a;
   --bg-raised: #111611;
-  --fg:        #c8e6c9;
-  --fg-dim:    #6b8a6b;
-  --accent:    #39ff14;
-  --accent-2:  #ff6e40;
-  --link:      #69f0ae;
-  --link-hover:#b9f6ca;
-  --border:    #2e4a2e;
-  --tag-bg:    #1a2e1a;
-  --spoken:    #ffab40;
-  --written:   #80cbc4;
-
+  --fg: #c8e6c9;
+  --fg-dim: #6b8a6b;
+  --accent: #39ff14;
+  --accent-2: #ff6e40;
+  --link: #69f0ae;
+  --link-hover: #b9f6ca;
+  --border: #2e4a2e;
+  --tag-bg: #1a2e1a;
+  --spoken: #ffab40;
+  --written: #80cbc4;
   --font: 'IBM Plex Mono', 'Courier New', monospace;
   --max-width: 900px;
   --gutter: 1.5rem;
 }
 
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
 }
 
-html { font-size: 14px; }
+html {
+  font-size: 14px;
+}
 
 body {
   font-family: var(--font);
@@ -91,7 +94,7 @@ header {
   align-items: start;
 }
 
-@media (max-width: 650px) {
+@media (width <= 650px) {
   .shell-layout {
     grid-template-columns: 1fr;
     gap: 2rem;
@@ -174,13 +177,29 @@ header {
 }
 
 /* color entry rows by type */
-.ls-table tbody tr.spoken a { color: var(--spoken); }
-.ls-table tbody tr.spoken a:hover { color: #ffcc80; }
-.ls-table tbody tr.spoken .ls-desc { color: #b57a2a; }
+.ls-table tbody tr.spoken a {
+  color: var(--spoken);
+}
 
-.ls-table tbody tr.written a { color: var(--written); }
-.ls-table tbody tr.written a:hover { color: #b2dfdb; }
-.ls-table tbody tr.written .ls-desc { color: #5f9ea0; }
+.ls-table tbody tr.spoken a:hover {
+  color: #ffcc80;
+}
+
+.ls-table tbody tr.spoken .ls-desc {
+  color: #b57a2a;
+}
+
+.ls-table tbody tr.written a {
+  color: var(--written);
+}
+
+.ls-table tbody tr.written a:hover {
+  color: #b2dfdb;
+}
+
+.ls-table tbody tr.written .ls-desc {
+  color: #5f9ea0;
+}
 
 /* year/month group headers */
 .ls-group-year td {
@@ -222,8 +241,13 @@ header {
   letter-spacing: 0.04em;
 }
 
-.ls-type.spoken { color: var(--spoken); }
-.ls-type.written { color: var(--written); }
+.ls-type.spoken {
+  color: var(--spoken);
+}
+
+.ls-type.written {
+  color: var(--written);
+}
 
 .ls-desc {
   color: var(--fg-dim);
@@ -258,8 +282,13 @@ header {
   letter-spacing: 0.05em;
 }
 
-.post-type.spoken { color: var(--spoken); }
-.post-type.written { color: var(--written); }
+.post-type.spoken {
+  color: var(--spoken);
+}
+
+.post-type.written {
+  color: var(--written);
+}
 
 .post-content h1 {
   font-size: 1.3rem;
@@ -345,7 +374,8 @@ header {
 
 .viz-embed .viz-label {
   position: absolute;
-  top: 0; left: 0;
+  top: 0;
+  left: 0;
   background: var(--accent);
   color: var(--bg);
   font-size: 0.55rem;
@@ -390,7 +420,9 @@ header {
   color: var(--link-hover);
 }
 
-.post-nav .next { margin-left: auto; }
+.post-nav .next {
+  margin-left: auto;
+}
 
 /* === VIM HINT === */
 
@@ -430,7 +462,7 @@ footer {
 .editor-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.88);
+  background: rgb(0 0 0 / 88%);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -460,16 +492,27 @@ footer {
   color: var(--fg-dim);
 }
 
-.editor-path { color: var(--fg); }
+.editor-path {
+  color: var(--fg);
+}
 
 .editor-type {
   font-size: 0.65rem;
   letter-spacing: 0.05em;
   cursor: pointer;
 }
-.editor-type:hover { opacity: 0.7; }
-.editor-type.spoken { color: var(--spoken); }
-.editor-type.written { color: var(--written); }
+
+.editor-type:hover {
+  opacity: 0.7;
+}
+
+.editor-type.spoken {
+  color: var(--spoken);
+}
+
+.editor-type.written {
+  color: var(--written);
+}
 
 .editor-fields {
   flex: 1;
@@ -520,8 +563,8 @@ footer {
 /* delete confirmation */
 .delete-header {
   background: #2a0a0a !important;
-  color: #ff4444 !important;
-  border-color: #ff4444 !important;
+  color: #f44 !important;
+  border-color: #f44 !important;
 }
 
 .delete-progress {
@@ -542,14 +585,19 @@ footer {
 }
 
 .delete-dot.active {
-  border-color: #ff4444;
-  color: #ff4444;
+  border-color: #f44;
+  color: #f44;
   background: #2a0a0a;
 }
 
 /* === RESPONSIVE === */
 
-@media (max-width: 650px) {
-  html { font-size: 13px; }
-  .tree-panel { min-width: unset; }
+@media (width <= 650px) {
+  html {
+    font-size: 13px;
+  }
+
+  .tree-panel {
+    min-width: unset;
+  }
 }

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -1,495 +1,528 @@
-/* log — editor.js — lazy-loaded, auth-gated */
-(function() {
-  'use strict';
-
-  var OWNER = 'RexGoliath1';
-  var REPO = 'vimsite';
-  var BRANCH = 'main';
-  var API = 'https://api.github.com/repos/' + OWNER + '/' + REPO;
-  var MONTHS = ['','january','february','march','april','may','june',
-    'july','august','september','october','november','december'];
-
-  // ====== Helpers ======
-
-  function esc(s) { return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
-  function today() {
-    var d = new Date();
-    return d.getFullYear() + '-' + String(d.getMonth()+1).padStart(2,'0') + '-' + String(d.getDate()).padStart(2,'0');
-  }
-  function slugify(t) { return t.toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-|-$/g,'').slice(0,50); }
-  function el(tag, cls) { var e = document.createElement(tag); if (cls) e.className = cls; return e; }
-
-  // ====== Auth ======
-
-  function getToken() { return localStorage.getItem('vimsite_token'); }
-  function setToken(t) { localStorage.setItem('vimsite_token', t); }
-
-  function requireAuth() {
-    return new Promise(function(resolve, reject) {
-      var t = getToken();
-      if (t) return resolve(t);
-      var ov = el('div','editor-overlay');
-      var box = el('div','editor-box');
-      box.style.maxWidth = '500px';
-      box.innerHTML =
-        '<div class="editor-header">github token required</div>' +
-        '<div style="padding:1rem">' +
-        '<p style="margin-bottom:1rem;color:var(--fg-dim);font-size:0.75rem">' +
-        'fine-grained PAT scoped to <strong>' + OWNER + '/' + REPO +
-        '</strong> with <strong>contents: read/write</strong></p>' +
-        '<input type="password" class="editor-input" id="ed-token" ' +
-        'placeholder="github_pat_..." style="width:100%">' +
-        '<p style="margin-top:0.75rem;font-size:0.65rem;color:var(--border)">' +
-        '<a href="https://github.com/settings/personal-access-tokens/new" ' +
-        'target="_blank" rel="noopener">create token</a></p></div>' +
-        '<div class="editor-status">enter: save · esc: cancel</div>';
+"use strict";
+(() => {
+  (function() {
+    "use strict";
+    const OWNER = "RexGoliath1";
+    const REPO = "vimsite";
+    const BRANCH = "main";
+    const API = "https://api.github.com/repos/" + OWNER + "/" + REPO;
+    const MONTHS = [
+      "",
+      "january",
+      "february",
+      "march",
+      "april",
+      "may",
+      "june",
+      "july",
+      "august",
+      "september",
+      "october",
+      "november",
+      "december"
+    ];
+    function esc(s) {
+      return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    }
+    function today() {
+      const d = /* @__PURE__ */ new Date();
+      return d.getFullYear() + "-" + String(d.getMonth() + 1).padStart(2, "0") + "-" + String(d.getDate()).padStart(2, "0");
+    }
+    function slugify(t) {
+      return t.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 50);
+    }
+    function el(tag, cls) {
+      const e = document.createElement(tag);
+      if (cls) e.className = cls;
+      return e;
+    }
+    function getToken() {
+      return localStorage.getItem("vimsite_token");
+    }
+    function setToken(t) {
+      localStorage.setItem("vimsite_token", t);
+    }
+    function requireAuth() {
+      return new Promise((resolve, reject) => {
+        const t = getToken();
+        if (t) return resolve(t);
+        const ov = el("div", "editor-overlay");
+        const box = el("div", "editor-box");
+        box.style.maxWidth = "500px";
+        box.innerHTML = '<div class="editor-header">github token required</div><div style="padding:1rem"><p style="margin-bottom:1rem;color:var(--fg-dim);font-size:0.75rem">fine-grained PAT scoped to <strong>' + OWNER + "/" + REPO + '</strong> with <strong>contents: read/write</strong></p><input type="password" class="editor-input" id="ed-token" placeholder="github_pat_..." style="width:100%"><p style="margin-top:0.75rem;font-size:0.65rem;color:var(--border)"><a href="https://github.com/settings/personal-access-tokens/new" target="_blank" rel="noopener">create token</a></p></div><div class="editor-status">enter: save \xB7 esc: cancel</div>';
+        ov.appendChild(box);
+        document.body.appendChild(ov);
+        const inp = document.getElementById("ed-token");
+        inp.focus();
+        inp.addEventListener("keydown", (e) => {
+          if (e.key === "Enter" && inp.value.trim()) {
+            setToken(inp.value.trim());
+            document.body.removeChild(ov);
+            resolve(inp.value.trim());
+          } else if (e.key === "Escape") {
+            document.body.removeChild(ov);
+            reject(new Error("cancelled"));
+          }
+        });
+      });
+    }
+    function gh(method, path, token, body) {
+      const opts = {
+        method,
+        headers: {
+          Authorization: "token " + token,
+          Accept: "application/vnd.github.v3+json"
+        }
+      };
+      if (body) {
+        opts.headers["Content-Type"] = "application/json";
+        opts.body = JSON.stringify(body);
+      }
+      return fetch(API + "/" + path, opts).then((r) => {
+        if (!r.ok) return r.text().then((t) => Promise.reject(new Error(r.status + ": " + t)));
+        return r.status === 204 ? null : r.json();
+      });
+    }
+    function getFile(path, token) {
+      return gh("GET", "contents/" + path + "?ref=" + BRANCH, token).then((d) => {
+        const raw = atob(d.content.replace(/\s/g, ""));
+        const bytes = new Uint8Array(raw.length);
+        for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
+        return { content: new TextDecoder().decode(bytes), sha: d.sha };
+      });
+    }
+    function multiCommit(token, message, files) {
+      let commitSha;
+      return gh("GET", "git/ref/heads/" + BRANCH, token).then((ref) => {
+        commitSha = ref.object.sha;
+        return gh("GET", "git/commits/" + commitSha, token);
+      }).then((commit) => {
+        const tree = files.map((f) => {
+          if (f.delete)
+            return { path: f.path, mode: "100644", type: "blob", sha: null };
+          return {
+            path: f.path,
+            mode: "100644",
+            type: "blob",
+            content: f.content
+          };
+        });
+        return gh("POST", "git/trees", token, { base_tree: commit.tree.sha, tree });
+      }).then((newTree) => {
+        return gh("POST", "git/commits", token, {
+          message,
+          tree: newTree.sha,
+          parents: [commitSha]
+        });
+      }).then((c) => {
+        return gh("PATCH", "git/refs/heads/" + BRANCH, token, { sha: c.sha }).then(() => {
+        });
+      });
+    }
+    function generatePost(o) {
+      const paras = o.content.split(/\n\n+/).filter(Boolean).map((p) => {
+        return "      <p>\n        " + esc(p.trim()).replace(/\n/g, "\n        ") + "\n      </p>";
+      }).join("\n\n");
+      let body;
+      if (o.type === "spoken") {
+        body = '    <div class="spoken-transcript">\n      <p class="spoken-label">transcribed via spokenly \xB7 lightly edited</p>\n\n' + paras + "\n    </div>";
+      } else {
+        body = paras;
+      }
+      const tags = (o.tags || []).map((t) => '      <span class="tag">' + esc(t) + "</span>").join("\n");
+      const nav = [];
+      if (o.prevSlug)
+        nav.push('    <a class="prev" href="' + o.prevSlug + '.html">\u2190 ' + o.prevSlug + "</a>");
+      nav.push(
+        '    <a class="back" href="../index.html">' + (o.prevSlug ? "" : "\u2190 ") + "~/log</a>"
+      );
+      if (o.nextSlug)
+        nav.push('    <a class="next" href="' + o.nextSlug + '.html">' + o.nextSlug + " \u2192</a>");
+      return '<!DOCTYPE html>\n<html lang="en">\n<head>\n  <meta charset="UTF-8">\n  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n  <title>' + o.slug + ' \u2014 log</title>\n  <link rel="stylesheet" href="../assets/css/style.css">\n</head>\n<body>\n  <header>\n    <nav style="font-size: 0.8rem; color: var(--fg-dim);">\n      <a href="../index.html">~/log</a> / ' + o.slug + '\n    </nav>\n  </header>\n\n  <main class="post-content">\n    <div class="post-meta">\n      <time datetime="' + o.date + '">' + o.date + '</time>\n      <span class="post-type ' + o.type + '">' + o.type + "</span>\n    </div>\n    <h1>" + o.slug + "</h1>\n\n" + body + '\n\n    <div class="post-tags">\n' + tags + '\n    </div>\n  </main>\n\n  <nav class="post-nav">\n' + nav.join("\n") + '\n  </nav>\n\n  <footer>\n    <p class="vim-hint">\u2190 \u2192 between posts \xB7 backspace ~/log \xB7 e edit</p>\n    <p class="footer-eof">EOF</p>\n  </footer>\n\n  <script src="../assets/js/main.js"><\/script>\n</body>\n</html>\n';
+    }
+    function parsePost(html) {
+      const doc = new DOMParser().parseFromString(html, "text/html");
+      let content = "";
+      const transcript = doc.querySelector(".spoken-transcript");
+      if (transcript) {
+        content = Array.from(transcript.querySelectorAll("p:not(.spoken-label)")).map((p) => p.textContent?.trim() ?? "").join("\n\n");
+      } else {
+        const main = doc.querySelector(".post-content");
+        if (main)
+          content = Array.from(main.querySelectorAll(":scope > p")).map((p) => p.textContent?.trim() ?? "").join("\n\n");
+      }
+      const typeEl = doc.querySelector(".post-type");
+      const prevEl = doc.querySelector(".post-nav .prev");
+      const nextEl = doc.querySelector(".post-nav .next");
+      return {
+        slug: doc.querySelector("h1")?.textContent ?? "",
+        date: doc.querySelector("time")?.getAttribute("datetime") ?? "",
+        type: typeEl?.classList.contains("spoken") ? "spoken" : "written",
+        content,
+        tags: Array.from(doc.querySelectorAll(".tag")).map((t) => t.textContent?.trim() ?? ""),
+        prevSlug: prevEl ? prevEl.getAttribute("href")?.replace(".html", "") ?? null : null,
+        nextSlug: nextEl ? nextEl.getAttribute("href")?.replace(".html", "") ?? null : null
+      };
+    }
+    function updatePostNav(html, prevSlug, nextSlug) {
+      const s = html.indexOf('<nav class="post-nav">');
+      const e = html.indexOf("</nav>", s) + 6;
+      if (s === -1) return html;
+      const nav = [];
+      if (prevSlug)
+        nav.push('    <a class="prev" href="' + prevSlug + '.html">\u2190 ' + prevSlug + "</a>");
+      nav.push(
+        '    <a class="back" href="../index.html">' + (prevSlug ? "" : "\u2190 ") + "~/log</a>"
+      );
+      if (nextSlug)
+        nav.push('    <a class="next" href="' + nextSlug + '.html">' + nextSlug + " \u2192</a>");
+      return html.slice(0, s) + '  <nav class="post-nav">\n' + nav.join("\n") + "\n  </nav>" + html.slice(e);
+    }
+    function addToIndex(html, date, type, slug, desc) {
+      const day = date.split("-")[2];
+      const ts = type === "spoken" ? "spkn" : "writ";
+      const month = MONTHS[+date.split("-")[1]];
+      const year = date.split("-")[0];
+      const row = '          <!-- post-row -->\n          <tr class="' + type + '">\n            <td class="ls-date" data-date="' + date + '">' + day + '</td>\n            <td class="ls-type ' + type + '">' + ts + '</td>\n            <td><a href="posts/' + slug + '.html">' + slug + '</a> <span class="ls-desc">\u2014 ' + esc(desc) + "</span></td>\n          </tr>\n          <!-- /post-row -->";
+      const hasYear = html.indexOf('ls-group-year"><td colspan="3">' + year + "<") > -1;
+      const hasMonth = html.indexOf('ls-group-month"><td colspan="3">' + month + "<") > -1;
+      if (hasMonth) {
+        const tag = 'ls-group-month"><td colspan="3">' + month + "</td></tr>";
+        const pos = html.indexOf(tag) + tag.length;
+        html = html.slice(0, pos) + "\n" + row + html.slice(pos);
+      } else if (hasYear) {
+        const tag = 'ls-group-year"><td colspan="3">' + year + "</td></tr>";
+        const pos = html.indexOf(tag) + tag.length;
+        html = html.slice(0, pos) + '\n          <tr class="ls-group-month"><td colspan="3">' + month + "</td></tr>\n" + row + html.slice(pos);
+      } else {
+        const pos = html.indexOf("<tbody>") + 7;
+        html = html.slice(0, pos) + '\n          <tr class="ls-group-year"><td colspan="3">' + year + '</td></tr>\n          <tr class="ls-group-month"><td colspan="3">' + month + "</td></tr>\n" + row + html.slice(pos);
+      }
+      return updateCount(html);
+    }
+    function removeFromIndex(html, slug) {
+      const marker = "posts/" + slug + ".html";
+      const pos = html.indexOf(marker);
+      if (pos === -1) return html;
+      let s = html.lastIndexOf("<!-- post-row -->", pos);
+      const e = html.indexOf("<!-- /post-row -->", pos) + 18;
+      while (s > 0 && html[s - 1] === " ") s--;
+      if (s > 0 && html[s - 1] === "\n") s--;
+      return updateCount(html.slice(0, s) + html.slice(e));
+    }
+    function updateCount(html) {
+      const m = html.match(/<!-- post-row -->/g);
+      const n = m ? m.length : 0;
+      return html.replace(
+        /<p class="ls-count">[^<]*<\/p>/,
+        '<p class="ls-count">' + (n === 1 ? "1 entry" : n + " entries") + "</p>"
+      );
+    }
+    function getNewestSlug(html) {
+      const s = html.indexOf("<!-- post-row -->");
+      if (s === -1) return null;
+      const chunk = html.slice(s, s + 500);
+      const m = chunk.match(/posts\/([^.]+)\.html/);
+      return m ? m[1] : null;
+    }
+    function getDescFromIndex(html, slug) {
+      const re = new RegExp(
+        "posts/" + slug + '\\.html">[^<]*</a>\\s*<span class="ls-desc">. ([^<]*)'
+      );
+      const m = html.match(re);
+      return m ? m[1] : "";
+    }
+    function showEditor(opts) {
+      let typeVal = opts.type || "spoken";
+      const ov = el("div", "editor-overlay");
+      const box = el("div", "editor-box");
+      box.innerHTML = '<div class="editor-header"><span class="editor-path">~/log/' + (opts.mode === "new" ? "new" : opts.slug) + '</span><span class="editor-type ' + typeVal + '" id="ed-type">' + typeVal + '</span></div><div class="editor-fields">' + (opts.mode === "new" ? '<input type="text" class="editor-input" id="ed-slug" placeholder="post-slug" value="">' : "") + '<textarea class="editor-textarea" id="ed-content" placeholder="start typing...">' + (opts.content || "") + '</textarea><input type="text" class="editor-input" id="ed-desc" placeholder="short description" value="' + (opts.desc || "").replace(/"/g, "&quot;") + '"><input type="text" class="editor-input" id="ed-tags" placeholder="tags (comma separated)" value="' + (opts.tags || []).join(", ") + '"></div><div class="editor-status" id="ed-status">esc \u2192 command mode \xB7 :w save \xB7 :q quit \xB7 :t toggle type</div>';
+      ov.setAttribute("tabindex", "-1");
       ov.appendChild(box);
       document.body.appendChild(ov);
-      var inp = document.getElementById('ed-token');
-      inp.focus();
-      inp.addEventListener('keydown', function(e) {
-        if (e.key === 'Enter' && inp.value.trim()) {
-          setToken(inp.value.trim());
-          document.body.removeChild(ov);
-          resolve(inp.value.trim());
-        } else if (e.key === 'Escape') {
-          document.body.removeChild(ov);
-          reject(new Error('cancelled'));
+      const ta = document.getElementById("ed-content");
+      const status = document.getElementById("ed-status");
+      const typeEl = document.getElementById("ed-type");
+      let cmdMode = false;
+      let cmdBuf = "";
+      ta.focus();
+      ta.addEventListener("input", () => {
+        const desc = document.getElementById("ed-desc");
+        if (!desc.dataset.manual) {
+          const words = ta.value.trim().split(/\s+/).slice(0, 8).join(" ");
+          desc.value = words.length > 50 ? words.slice(0, 50) + "..." : words;
         }
       });
-    });
-  }
-
-  // ====== GitHub API ======
-
-  function gh(method, path, token, body) {
-    var opts = {
-      method: method,
-      headers: { 'Authorization': 'token ' + token, 'Accept': 'application/vnd.github.v3+json' }
-    };
-    if (body) { opts.headers['Content-Type'] = 'application/json'; opts.body = JSON.stringify(body); }
-    return fetch(API + '/' + path, opts).then(function(r) {
-      if (!r.ok) return r.text().then(function(t) { throw new Error(r.status + ': ' + t); });
-      return r.status === 204 ? null : r.json();
-    });
-  }
-
-  function getFile(path, token) {
-    return gh('GET', 'contents/' + path + '?ref=' + BRANCH, token).then(function(d) {
-      var raw = atob(d.content.replace(/\s/g, ''));
-      var bytes = new Uint8Array(raw.length);
-      for (var i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
-      return { content: new TextDecoder().decode(bytes), sha: d.sha };
-    });
-  }
-
-  function multiCommit(token, message, files) {
-    var commitSha;
-    return gh('GET', 'git/ref/heads/' + BRANCH, token).then(function(ref) {
-      commitSha = ref.object.sha;
-      return gh('GET', 'git/commits/' + commitSha, token);
-    }).then(function(commit) {
-      var tree = files.map(function(f) {
-        if (f.delete) return { path: f.path, mode: '100644', type: 'blob', sha: null };
-        return { path: f.path, mode: '100644', type: 'blob', content: f.content };
+      document.getElementById("ed-desc").addEventListener("input", function() {
+        this.dataset.manual = "1";
       });
-      return gh('POST', 'git/trees', token, { base_tree: commit.tree.sha, tree: tree });
-    }).then(function(newTree) {
-      return gh('POST', 'git/commits', token, { message: message, tree: newTree.sha, parents: [commitSha] });
-    }).then(function(c) {
-      return gh('PATCH', 'git/refs/heads/' + BRANCH, token, { sha: c.sha });
-    });
-  }
-
-  // ====== Post HTML ======
-
-  function generatePost(o) {
-    var paras = o.content.split(/\n\n+/).filter(Boolean).map(function(p) {
-      return '      <p>\n        ' + esc(p.trim()).replace(/\n/g, '\n        ') + '\n      </p>';
-    }).join('\n\n');
-
-    var body;
-    if (o.type === 'spoken') {
-      body = '    <div class="spoken-transcript">\n' +
-        '      <p class="spoken-label">transcribed via spokenly · lightly edited</p>\n\n' +
-        paras + '\n    </div>';
-    } else {
-      body = paras;
-    }
-
-    var tags = (o.tags || []).map(function(t) {
-      return '      <span class="tag">' + esc(t) + '</span>';
-    }).join('\n');
-
-    var nav = [];
-    if (o.prevSlug) nav.push('    <a class="prev" href="' + o.prevSlug + '.html">\u2190 ' + o.prevSlug + '</a>');
-    nav.push('    <a class="back" href="../index.html">' + (o.prevSlug ? '' : '\u2190 ') + '~/log</a>');
-    if (o.nextSlug) nav.push('    <a class="next" href="' + o.nextSlug + '.html">' + o.nextSlug + ' \u2192</a>');
-
-    return '<!DOCTYPE html>\n<html lang="en">\n<head>\n' +
-      '  <meta charset="UTF-8">\n  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n' +
-      '  <title>' + o.slug + ' \u2014 log</title>\n' +
-      '  <link rel="stylesheet" href="../assets/css/style.css">\n</head>\n<body>\n' +
-      '  <header>\n    <nav style="font-size: 0.8rem; color: var(--fg-dim);">\n' +
-      '      <a href="../index.html">~/log</a> / ' + o.slug + '\n    </nav>\n  </header>\n\n' +
-      '  <main class="post-content">\n' +
-      '    <div class="post-meta">\n      <time datetime="' + o.date + '">' + o.date + '</time>\n' +
-      '      <span class="post-type ' + o.type + '">' + o.type + '</span>\n    </div>\n' +
-      '    <h1>' + o.slug + '</h1>\n\n' + body + '\n\n' +
-      '    <div class="post-tags">\n' + tags + '\n    </div>\n  </main>\n\n' +
-      '  <nav class="post-nav">\n' + nav.join('\n') + '\n  </nav>\n\n' +
-      '  <footer>\n    <p class="vim-hint">\u2190 \u2192 between posts \u00b7 backspace ~/log \u00b7 e edit</p>\n' +
-      '    <p class="footer-eof">EOF</p>\n  </footer>\n\n' +
-      '  <script src="../assets/js/main.js"></script>\n</body>\n</html>\n';
-  }
-
-  function parsePost(html) {
-    var doc = new DOMParser().parseFromString(html, 'text/html');
-    var content = '';
-    var transcript = doc.querySelector('.spoken-transcript');
-    if (transcript) {
-      content = Array.from(transcript.querySelectorAll('p:not(.spoken-label)'))
-        .map(function(p) { return p.textContent.trim(); }).join('\n\n');
-    } else {
-      var main = doc.querySelector('.post-content');
-      if (main) content = Array.from(main.querySelectorAll(':scope > p'))
-        .map(function(p) { return p.textContent.trim(); }).join('\n\n');
-    }
-    var typeEl = doc.querySelector('.post-type');
-    var prevEl = doc.querySelector('.post-nav .prev');
-    var nextEl = doc.querySelector('.post-nav .next');
-    return {
-      slug: (doc.querySelector('h1') || {}).textContent || '',
-      date: (doc.querySelector('time') || {}).getAttribute('datetime') || '',
-      type: typeEl && typeEl.classList.contains('spoken') ? 'spoken' : 'written',
-      content: content,
-      tags: Array.from(doc.querySelectorAll('.tag')).map(function(t) { return t.textContent.trim(); }),
-      prevSlug: prevEl ? prevEl.getAttribute('href').replace('.html','') : null,
-      nextSlug: nextEl ? nextEl.getAttribute('href').replace('.html','') : null
-    };
-  }
-
-  // Update only the nav section of a post (preserves all other HTML)
-  function updatePostNav(html, prevSlug, nextSlug) {
-    var s = html.indexOf('<nav class="post-nav">');
-    var e = html.indexOf('</nav>', s) + 6;
-    if (s === -1) return html;
-    var nav = [];
-    if (prevSlug) nav.push('    <a class="prev" href="' + prevSlug + '.html">\u2190 ' + prevSlug + '</a>');
-    nav.push('    <a class="back" href="../index.html">' + (prevSlug ? '' : '\u2190 ') + '~/log</a>');
-    if (nextSlug) nav.push('    <a class="next" href="' + nextSlug + '.html">' + nextSlug + ' \u2192</a>');
-    return html.slice(0, s) + '  <nav class="post-nav">\n' + nav.join('\n') + '\n  </nav>' + html.slice(e);
-  }
-
-  // ====== Index manipulation ======
-
-  function addToIndex(html, date, type, slug, desc) {
-    var day = date.split('-')[2];
-    var ts = type === 'spoken' ? 'spkn' : 'writ';
-    var month = MONTHS[+date.split('-')[1]];
-    var year = date.split('-')[0];
-
-    var row = '          <!-- post-row -->\n' +
-      '          <tr class="' + type + '">\n' +
-      '            <td class="ls-date" data-date="' + date + '">' + day + '</td>\n' +
-      '            <td class="ls-type ' + type + '">' + ts + '</td>\n' +
-      '            <td><a href="posts/' + slug + '.html">' + slug + '</a> ' +
-      '<span class="ls-desc">\u2014 ' + esc(desc) + '</span></td>\n' +
-      '          </tr>\n          <!-- /post-row -->';
-
-    var hasYear = html.indexOf('ls-group-year"><td colspan="3">' + year + '<') > -1;
-    var hasMonth = html.indexOf('ls-group-month"><td colspan="3">' + month + '<') > -1;
-
-    if (hasMonth) {
-      var tag = 'ls-group-month"><td colspan="3">' + month + '</td></tr>';
-      var pos = html.indexOf(tag) + tag.length;
-      html = html.slice(0, pos) + '\n' + row + html.slice(pos);
-    } else if (hasYear) {
-      var tag = 'ls-group-year"><td colspan="3">' + year + '</td></tr>';
-      var pos = html.indexOf(tag) + tag.length;
-      html = html.slice(0, pos) + '\n          <tr class="ls-group-month"><td colspan="3">' +
-        month + '</td></tr>\n' + row + html.slice(pos);
-    } else {
-      var pos = html.indexOf('<tbody>') + 7;
-      html = html.slice(0, pos) + '\n          <tr class="ls-group-year"><td colspan="3">' +
-        year + '</td></tr>\n          <tr class="ls-group-month"><td colspan="3">' +
-        month + '</td></tr>\n' + row + html.slice(pos);
-    }
-    return updateCount(html);
-  }
-
-  function removeFromIndex(html, slug) {
-    var marker = 'posts/' + slug + '.html';
-    var pos = html.indexOf(marker);
-    if (pos === -1) return html;
-    var s = html.lastIndexOf('<!-- post-row -->', pos);
-    var e = html.indexOf('<!-- /post-row -->', pos) + 18;
-    while (s > 0 && html[s-1] === ' ') s--;
-    if (s > 0 && html[s-1] === '\n') s--;
-    return updateCount(html.slice(0, s) + html.slice(e));
-  }
-
-  function updateCount(html) {
-    var m = html.match(/<!-- post-row -->/g);
-    var n = m ? m.length : 0;
-    return html.replace(/<p class="ls-count">[^<]*<\/p>/,
-      '<p class="ls-count">' + (n === 1 ? '1 entry' : n + ' entries') + '</p>');
-  }
-
-  function getNewestSlug(html) {
-    var s = html.indexOf('<!-- post-row -->');
-    if (s === -1) return null;
-    var chunk = html.slice(s, s + 500);
-    var m = chunk.match(/posts\/([^.]+)\.html/);
-    return m ? m[1] : null;
-  }
-
-  function getDescFromIndex(html, slug) {
-    var re = new RegExp('posts/' + slug + '\\.html">[^<]*</a>\\s*<span class="ls-desc">. ([^<]*)');
-    var m = html.match(re);
-    return m ? m[1] : '';
-  }
-
-  // ====== Editor UI ======
-
-  function showEditor(opts) {
-    var typeVal = opts.type || 'spoken';
-    var ov = el('div', 'editor-overlay');
-    var box = el('div', 'editor-box');
-    box.innerHTML =
-      '<div class="editor-header">' +
-      '<span class="editor-path">~/log/' + (opts.mode === 'new' ? 'new' : opts.slug) + '</span>' +
-      '<span class="editor-type ' + typeVal + '" id="ed-type">' + typeVal + '</span></div>' +
-      '<div class="editor-fields">' +
-      (opts.mode === 'new' ? '<input type="text" class="editor-input" id="ed-slug" placeholder="post-slug" value="">' : '') +
-      '<textarea class="editor-textarea" id="ed-content" placeholder="start typing...">' +
-      (opts.content || '') + '</textarea>' +
-      '<input type="text" class="editor-input" id="ed-desc" placeholder="short description" value="' +
-      (opts.desc || '').replace(/"/g, '&quot;') + '">' +
-      '<input type="text" class="editor-input" id="ed-tags" placeholder="tags (comma separated)" value="' +
-      (opts.tags || []).join(', ') + '"></div>' +
-      '<div class="editor-status" id="ed-status">esc \u2192 command mode \u00b7 :w save \u00b7 :q quit \u00b7 :t toggle type</div>';
-
-    ov.setAttribute('tabindex', '-1');
-    ov.appendChild(box);
-    document.body.appendChild(ov);
-
-    var ta = document.getElementById('ed-content');
-    var status = document.getElementById('ed-status');
-    var typeEl = document.getElementById('ed-type');
-    var cmdMode = false, cmdBuf = '';
-    ta.focus();
-
-    // auto-fill description from content
-    ta.addEventListener('input', function() {
-      var desc = document.getElementById('ed-desc');
-      if (!desc.dataset.manual) {
-        var words = ta.value.trim().split(/\s+/).slice(0, 8).join(' ');
-        desc.value = words.length > 50 ? words.slice(0, 50) + '...' : words;
-      }
-    });
-    document.getElementById('ed-desc').addEventListener('input', function() { this.dataset.manual = '1'; });
-
-    // clickable type toggle
-    typeEl.addEventListener('click', function() {
-      typeVal = typeVal === 'spoken' ? 'written' : 'spoken';
-      typeEl.textContent = typeVal;
-      typeEl.className = 'editor-type ' + typeVal;
-    });
-
-    function cleanup() { if (ov.parentNode) document.body.removeChild(ov); }
-
-    function execCmd(cmd) {
-      cmd = cmd.trim().toLowerCase();
-      if (cmd === 'w' || cmd === 'wq') {
-        var slug = opts.mode === 'new'
-          ? slugify(document.getElementById('ed-slug').value.trim() || ta.value.slice(0, 40))
-          : opts.slug;
-        if (!slug) { status.textContent = 'error: need a slug'; return; }
-        if (!ta.value.trim()) { status.textContent = 'error: no content'; return; }
-        status.textContent = 'saving...';
-        var result = {
-          slug: slug, type: typeVal, content: ta.value,
-          desc: document.getElementById('ed-desc').value.trim() || slug,
-          tags: document.getElementById('ed-tags').value.split(',').map(function(s) { return s.trim(); }).filter(Boolean)
-        };
-        opts.onSave(result).then(function() {
-          if (cmd === 'wq') {
-            cleanup();
-          } else {
-            status.textContent = 'committed. reload in ~15s to see changes.';
-          }
-        }).catch(function(err) {
-          status.textContent = 'error: ' + err.message;
-          if (err.message.indexOf('401') > -1 || err.message.indexOf('403') > -1) {
-            localStorage.removeItem('vimsite_token');
-            status.textContent = 'bad token \u2014 cleared. reload and try again.';
-          }
-        });
-      } else if (cmd === 'q' || cmd === 'q!') {
-        cleanup();
-      } else if (cmd === 't') {
-        typeVal = typeVal === 'spoken' ? 'written' : 'spoken';
+      typeEl.addEventListener("click", () => {
+        typeVal = typeVal === "spoken" ? "written" : "spoken";
         typeEl.textContent = typeVal;
-        typeEl.className = 'editor-type ' + typeVal;
-        status.textContent = 'type: ' + typeVal;
-        cmdMode = false; ta.focus();
-      } else {
-        status.textContent = 'unknown: :' + cmd;
+        typeEl.className = "editor-type " + typeVal;
+      });
+      function cleanup() {
+        if (ov.parentNode) document.body.removeChild(ov);
       }
+      function execCmd(cmd) {
+        cmd = cmd.trim().toLowerCase();
+        if (cmd === "w" || cmd === "wq") {
+          const slug = opts.mode === "new" ? slugify(
+            document.getElementById("ed-slug").value.trim() || ta.value.slice(0, 40)
+          ) : opts.slug;
+          if (!slug) {
+            status.textContent = "error: need a slug";
+            return;
+          }
+          if (!ta.value.trim()) {
+            status.textContent = "error: no content";
+            return;
+          }
+          status.textContent = "saving...";
+          const result = {
+            slug,
+            type: typeVal,
+            content: ta.value,
+            desc: document.getElementById("ed-desc").value.trim() || slug,
+            tags: document.getElementById("ed-tags").value.split(",").map((s) => s.trim()).filter(Boolean)
+          };
+          opts.onSave(result).then(
+            () => {
+              if (cmd === "wq") {
+                cleanup();
+              } else {
+                status.textContent = "committed. reload in ~15s to see changes.";
+              }
+            },
+            (err) => {
+              status.textContent = "error: " + err.message;
+              if (err.message.indexOf("401") > -1 || err.message.indexOf("403") > -1) {
+                localStorage.removeItem("vimsite_token");
+                status.textContent = "bad token \u2014 cleared. reload and try again.";
+              }
+            }
+          );
+        } else if (cmd === "q" || cmd === "q!") {
+          cleanup();
+        } else if (cmd === "t") {
+          typeVal = typeVal === "spoken" ? "written" : "spoken";
+          typeEl.textContent = typeVal;
+          typeEl.className = "editor-type " + typeVal;
+          status.textContent = "type: " + typeVal;
+          cmdMode = false;
+          ta.focus();
+        } else {
+          status.textContent = "unknown: :" + cmd;
+        }
+      }
+      ov.addEventListener("keydown", (e) => {
+        if (cmdMode) {
+          e.stopPropagation();
+          if (e.key === "Enter") {
+            e.preventDefault();
+            execCmd(cmdBuf);
+            cmdMode = false;
+            cmdBuf = "";
+          } else if (e.key === "Escape") {
+            cmdMode = false;
+            cmdBuf = "";
+            status.textContent = "esc \u2192 command mode";
+            ta.focus();
+          } else if (e.key === "Backspace") {
+            cmdBuf = cmdBuf.slice(0, -1);
+            status.textContent = ":" + cmdBuf;
+            if (!cmdBuf) {
+              cmdMode = false;
+              status.textContent = "esc \u2192 command mode";
+              ta.focus();
+            }
+          } else if (e.key.length === 1) {
+            cmdBuf += e.key;
+            status.textContent = ":" + cmdBuf;
+          }
+          return;
+        }
+        if (e.key === "Escape") {
+          e.preventDefault();
+          cmdMode = true;
+          cmdBuf = "";
+          status.textContent = ":";
+          ta.blur();
+          ov.focus();
+        }
+      });
     }
-
-    ov.addEventListener('keydown', function(e) {
-      if (cmdMode) {
+    function showDeleteConfirm(slug, onConfirm) {
+      const ov = el("div", "editor-overlay");
+      const box = el("div", "editor-box");
+      box.style.maxWidth = "450px";
+      let stage = 0;
+      const msgs = [
+        "press d to confirm \xB7 any other key to cancel",
+        "press d again \xB7 any other key to cancel",
+        "FINAL \u2014 press d to delete permanently"
+      ];
+      function render() {
+        box.innerHTML = '<div class="editor-header delete-header">!! delete ' + slug + ' !!</div><div style="padding:1.5rem;text-align:center"><p style="font-size:0.8rem">' + msgs[stage] + '</p><div class="delete-progress"><span class="delete-dot ' + (stage >= 0 ? "active" : "") + '">d</span><span class="delete-dot ' + (stage >= 1 ? "active" : "") + '">d</span><span class="delete-dot ' + (stage >= 2 ? "active" : "") + '">d</span></div></div>';
+      }
+      render();
+      ov.appendChild(box);
+      document.body.appendChild(ov);
+      function handler(e) {
+        e.preventDefault();
         e.stopPropagation();
-        if (e.key === 'Enter') { e.preventDefault(); execCmd(cmdBuf); cmdMode = false; cmdBuf = ''; }
-        else if (e.key === 'Escape') { cmdMode = false; cmdBuf = ''; status.textContent = 'esc \u2192 command mode'; ta.focus(); }
-        else if (e.key === 'Backspace') { cmdBuf = cmdBuf.slice(0,-1); status.textContent = ':' + cmdBuf; if (!cmdBuf) { cmdMode = false; status.textContent = 'esc \u2192 command mode'; ta.focus(); } }
-        else if (e.key.length === 1) { cmdBuf += e.key; status.textContent = ':' + cmdBuf; }
-        return;
-      }
-      if (e.key === 'Escape') { e.preventDefault(); cmdMode = true; cmdBuf = ''; status.textContent = ':'; ta.blur(); ov.focus(); }
-    });
-  }
-
-  function showDeleteConfirm(slug, onConfirm) {
-    var ov = el('div', 'editor-overlay');
-    var box = el('div', 'editor-box');
-    box.style.maxWidth = '450px';
-    var stage = 0;
-    var msgs = [
-      'press d to confirm \u00b7 any other key to cancel',
-      'press d again \u00b7 any other key to cancel',
-      'FINAL \u2014 press d to delete permanently'
-    ];
-    function render() {
-      box.innerHTML = '<div class="editor-header delete-header">!! delete ' + slug + ' !!</div>' +
-        '<div style="padding:1.5rem;text-align:center"><p style="font-size:0.8rem">' + msgs[stage] + '</p>' +
-        '<div class="delete-progress">' +
-        '<span class="delete-dot ' + (stage >= 0 ? 'active' : '') + '">d</span>' +
-        '<span class="delete-dot ' + (stage >= 1 ? 'active' : '') + '">d</span>' +
-        '<span class="delete-dot ' + (stage >= 2 ? 'active' : '') + '">d</span>' +
-        '</div></div>';
-    }
-    render();
-    ov.appendChild(box);
-    document.body.appendChild(ov);
-
-    function handler(e) {
-      e.preventDefault(); e.stopPropagation();
-      if (e.key === 'd') {
-        stage++;
-        if (stage >= 3) {
-          document.removeEventListener('keydown', handler, true);
-          box.innerHTML = '<div class="editor-header delete-header">!! deleting !!</div>' +
-            '<div style="padding:1.5rem;text-align:center"><p style="font-size:0.8rem">removing...</p></div>';
-          onConfirm().then(function() {
-            box.querySelector('p').textContent = 'done. reload to see changes.';
-            setTimeout(function() { document.body.removeChild(ov); }, 2000);
-          }).catch(function(err) {
-            box.querySelector('p').textContent = 'error: ' + err.message;
-          });
-        } else { render(); }
-      } else {
-        document.removeEventListener('keydown', handler, true);
-        document.body.removeChild(ov);
-      }
-    }
-    document.addEventListener('keydown', handler, true);
-  }
-
-  // ====== Workflows ======
-
-  function newEntry(token) {
-    showEditor({
-      mode: 'new', type: 'spoken',
-      onSave: function(r) {
-        return getFile('index.html', token).then(function(idx) {
-          var newest = getNewestSlug(idx.content);
-          var date = today();
-          var postHtml = generatePost({
-            slug: r.slug, date: date, type: r.type, content: r.content,
-            tags: r.tags, prevSlug: null, nextSlug: newest
-          });
-          var newIndex = addToIndex(idx.content, date, r.type, r.slug, r.desc);
-          var files = [
-            { path: 'posts/' + r.slug + '.html', content: postHtml },
-            { path: 'index.html', content: newIndex }
-          ];
-          if (newest) {
-            return getFile('posts/' + newest + '.html', token).then(function(f) {
-              files.push({ path: 'posts/' + newest + '.html', content: updatePostNav(f.content, r.slug, parsePost(f.content).nextSlug) });
-              return multiCommit(token, 'feat: add post ' + r.slug, files);
-            });
+        if (e.key === "d") {
+          stage++;
+          if (stage >= 3) {
+            document.removeEventListener("keydown", handler, true);
+            box.innerHTML = '<div class="editor-header delete-header">!! deleting !!</div><div style="padding:1.5rem;text-align:center"><p style="font-size:0.8rem">removing...</p></div>';
+            onConfirm().then(
+              () => {
+                const p = box.querySelector("p");
+                if (p) p.textContent = "done. reload to see changes.";
+                setTimeout(() => {
+                  if (ov.parentNode) document.body.removeChild(ov);
+                }, 2e3);
+              },
+              (err) => {
+                const p = box.querySelector("p");
+                if (p) p.textContent = "error: " + err.message;
+              }
+            );
+          } else {
+            render();
           }
-          return multiCommit(token, 'feat: add post ' + r.slug, files);
-        });
+        } else {
+          document.removeEventListener("keydown", handler, true);
+          document.body.removeChild(ov);
+        }
       }
-    });
-  }
-
-  function editEntry(slug, token) {
-    return getFile('posts/' + slug + '.html', token).then(function(file) {
-      var post = parsePost(file.content);
-      return getFile('index.html', token).then(function(idx) {
-        var desc = getDescFromIndex(idx.content, slug);
-        showEditor({
-          mode: 'edit', slug: slug, type: post.type,
-          content: post.content, tags: post.tags, desc: desc,
-          onSave: function(r) {
-            var postHtml = generatePost({
-              slug: slug, date: post.date, type: r.type, content: r.content,
-              tags: r.tags, prevSlug: post.prevSlug, nextSlug: post.nextSlug
+      document.addEventListener("keydown", handler, true);
+    }
+    function newEntry(token) {
+      showEditor({
+        mode: "new",
+        type: "spoken",
+        onSave: (r) => {
+          return getFile("index.html", token).then((idx) => {
+            const newest = getNewestSlug(idx.content);
+            const date = today();
+            const postHtml = generatePost({
+              slug: r.slug,
+              date,
+              type: r.type,
+              content: r.content,
+              tags: r.tags,
+              prevSlug: null,
+              nextSlug: newest
             });
-            var newIndex = removeFromIndex(idx.content, slug);
-            newIndex = addToIndex(newIndex, post.date, r.type, slug, r.desc);
-            return multiCommit(token, 'edit: update ' + slug, [
-              { path: 'posts/' + slug + '.html', content: postHtml },
-              { path: 'index.html', content: newIndex }
-            ]);
-          }
-        });
+            const newIndex = addToIndex(idx.content, date, r.type, r.slug, r.desc);
+            const files = [
+              { path: "posts/" + r.slug + ".html", content: postHtml },
+              { path: "index.html", content: newIndex }
+            ];
+            if (newest) {
+              return getFile("posts/" + newest + ".html", token).then((f) => {
+                const parsed = parsePost(f.content);
+                files.push({
+                  path: "posts/" + newest + ".html",
+                  content: updatePostNav(f.content, r.slug, parsed.nextSlug)
+                });
+                return multiCommit(token, "feat: add post " + r.slug, files);
+              });
+            }
+            return multiCommit(token, "feat: add post " + r.slug, files);
+          });
+        }
       });
-    });
-  }
-
-  function deleteEntry(slug, token) {
-    showDeleteConfirm(slug, function() {
-      return getFile('posts/' + slug + '.html', token).then(function(file) {
-        var post = parsePost(file.content);
-        return getFile('index.html', token).then(function(idx) {
-          var newIndex = removeFromIndex(idx.content, slug);
-          var files = [
-            { path: 'posts/' + slug + '.html', delete: true },
-            { path: 'index.html', content: newIndex }
-          ];
-          var adj = [];
-          if (post.prevSlug) {
-            adj.push(getFile('posts/' + post.prevSlug + '.html', token).then(function(f) {
-              files.push({ path: 'posts/' + post.prevSlug + '.html',
-                content: updatePostNav(f.content, parsePost(f.content).prevSlug, post.nextSlug) });
-            }));
-          }
-          if (post.nextSlug) {
-            adj.push(getFile('posts/' + post.nextSlug + '.html', token).then(function(f) {
-              files.push({ path: 'posts/' + post.nextSlug + '.html',
-                content: updatePostNav(f.content, post.prevSlug, parsePost(f.content).nextSlug) });
-            }));
-          }
-          return Promise.all(adj).then(function() {
-            return multiCommit(token, 'delete: remove ' + slug, files);
+    }
+    function editEntry(slug, token) {
+      getFile("posts/" + slug + ".html", token).then((file) => {
+        const post = parsePost(file.content);
+        getFile("index.html", token).then((idx) => {
+          const desc = getDescFromIndex(idx.content, slug);
+          showEditor({
+            mode: "edit",
+            slug,
+            type: post.type,
+            content: post.content,
+            tags: post.tags,
+            desc,
+            onSave: (r) => {
+              const postHtml = generatePost({
+                slug,
+                date: post.date,
+                type: r.type,
+                content: r.content,
+                tags: r.tags,
+                prevSlug: post.prevSlug,
+                nextSlug: post.nextSlug
+              });
+              let newIndex = removeFromIndex(idx.content, slug);
+              newIndex = addToIndex(newIndex, post.date, r.type, slug, r.desc);
+              return multiCommit(token, "edit: update " + slug, [
+                { path: "posts/" + slug + ".html", content: postHtml },
+                { path: "index.html", content: newIndex }
+              ]);
+            }
           });
         });
       });
-    });
-  }
-
-  // ====== Public API ======
-
-  window.__editor = {
-    newEntry: function() { requireAuth().then(newEntry).catch(function(){}); },
-    editEntry: function(slug) { requireAuth().then(function(t) { editEntry(slug, t); }).catch(function(){}); },
-    deleteEntry: function(slug) { requireAuth().then(function(t) { deleteEntry(slug, t); }).catch(function(){}); },
-    clearToken: function() { localStorage.removeItem('vimsite_token'); }
-  };
+    }
+    function deleteEntry(slug, token) {
+      showDeleteConfirm(slug, () => {
+        return getFile("posts/" + slug + ".html", token).then((file) => {
+          const post = parsePost(file.content);
+          return getFile("index.html", token).then((idx) => {
+            const newIndex = removeFromIndex(idx.content, slug);
+            const files = [
+              { path: "posts/" + slug + ".html", delete: true },
+              { path: "index.html", content: newIndex }
+            ];
+            const adj = [];
+            if (post.prevSlug) {
+              adj.push(
+                getFile("posts/" + post.prevSlug + ".html", token).then((f) => {
+                  files.push({
+                    path: "posts/" + post.prevSlug + ".html",
+                    content: updatePostNav(f.content, parsePost(f.content).prevSlug, post.nextSlug)
+                  });
+                })
+              );
+            }
+            if (post.nextSlug) {
+              adj.push(
+                getFile("posts/" + post.nextSlug + ".html", token).then((f) => {
+                  files.push({
+                    path: "posts/" + post.nextSlug + ".html",
+                    content: updatePostNav(f.content, post.prevSlug, parsePost(f.content).nextSlug)
+                  });
+                })
+              );
+            }
+            return Promise.all(adj).then(() => {
+              return multiCommit(token, "delete: remove " + slug, files);
+            });
+          });
+        });
+      });
+    }
+    window.__editor = {
+      newEntry: () => {
+        requireAuth().then(newEntry).catch(() => {
+        });
+      },
+      editEntry: (slug) => {
+        requireAuth().then((t) => editEntry(slug, t)).catch(() => {
+        });
+      },
+      deleteEntry: (slug) => {
+        requireAuth().then((t) => deleteEntry(slug, t)).catch(() => {
+        });
+      },
+      clearToken: () => {
+        localStorage.removeItem("vimsite_token");
+      }
+    };
+  })();
 })();

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,139 +1,120 @@
-/* log — main.js — minimal */
-
-(function() {
-  'use strict';
-
-  // --- J2000 day number (days since 2000-01-01 12:00 TT) ---
-  function j2000(y, m, d) {
-    var a = Math.floor((14 - m) / 12);
-    var yy = y + 4800 - a;
-    var mm = m + 12 * a - 3;
-    var jdn = d + Math.floor((153 * mm + 2) / 5) + 365 * yy +
-              Math.floor(yy / 4) - Math.floor(yy / 100) + Math.floor(yy / 400) - 32045;
-    return jdn - 2451545;
-  }
-
-  function injectJ2000() {
-    document.querySelectorAll('.ls-date[data-date]').forEach(function(el) {
-      var p = el.dataset.date.split('-');
-      var span = document.createElement('span');
-      span.className = 'j2000';
-      span.textContent = 'J' + j2000(+p[0], +p[1], +p[2]);
-      el.appendChild(span);
-    });
-    document.querySelectorAll('.post-meta time[datetime]').forEach(function(el) {
-      var p = el.getAttribute('datetime').split('-');
-      var span = document.createElement('span');
-      span.className = 'j2000';
-      span.textContent = 'J' + j2000(+p[0], +p[1], +p[2]);
-      el.parentNode.insertBefore(span, el.nextSibling);
-    });
-  }
-
-  injectJ2000();
-
-  // --- lazy-load editor.js ---
-  function loadEditor(fn) {
-    if (window.__editor) { fn(); return; }
-    var s = document.createElement('script');
-    var isPost = !!document.querySelector('.post-content');
-    s.src = (isPost ? '../' : '') + 'assets/js/editor.js';
-    s.onload = fn;
-    document.head.appendChild(s);
-  }
-
-  // --- vim j/k/↑/↓/Enter nav on ls table rows (skips group headers) ---
-  var rows = document.querySelectorAll('.ls-table tbody tr:not(.ls-group-year):not(.ls-group-month)');
-  var cur = -1;
-
-  function select(i) {
-    rows.forEach(function(r) { r.classList.remove('selected'); });
-    if (i >= 0 && i < rows.length) {
-      rows[i].classList.add('selected');
-      rows[i].scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+"use strict";
+(() => {
+  (function() {
+    "use strict";
+    function j2000(y, m, d) {
+      const a = Math.floor((14 - m) / 12);
+      const yy = y + 4800 - a;
+      const mm = m + 12 * a - 3;
+      const jdn = d + Math.floor((153 * mm + 2) / 5) + 365 * yy + Math.floor(yy / 4) - Math.floor(yy / 100) + Math.floor(yy / 400) - 32045;
+      return jdn - 2451545;
     }
-  }
-
-  function getSelectedSlug() {
-    if (cur < 0 || !rows[cur]) return null;
-    var link = rows[cur].querySelector('a');
-    if (!link) return null;
-    var m = link.getAttribute('href').match(/posts\/([^.]+)\.html/);
-    return m ? m[1] : null;
-  }
-
-  function getCurrentSlug() {
-    var m = location.pathname.match(/posts\/([^.]+)\.html/);
-    return m ? m[1] : null;
-  }
-
-  document.addEventListener('keydown', function(e) {
-    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
-    if (document.querySelector('.editor-overlay')) return;
-
-    // j / ArrowDown — move down
-    if (e.key === 'j' || e.key === 'ArrowDown') {
-      if (!rows.length) return;
-      e.preventDefault();
-      cur = Math.min(cur + 1, rows.length - 1);
-      select(cur);
+    function injectJ2000() {
+      document.querySelectorAll(".ls-date[data-date]").forEach((el) => {
+        const p = (el.dataset.date ?? "").split("-");
+        const span = document.createElement("span");
+        span.className = "j2000";
+        span.textContent = "J" + j2000(+p[0], +p[1], +p[2]);
+        el.appendChild(span);
+      });
+      document.querySelectorAll(".post-meta time[datetime]").forEach((el) => {
+        const p = (el.getAttribute("datetime") ?? "").split("-");
+        const span = document.createElement("span");
+        span.className = "j2000";
+        span.textContent = "J" + j2000(+p[0], +p[1], +p[2]);
+        el.parentNode?.insertBefore(span, el.nextSibling);
+      });
     }
-    // k / ArrowUp — move up
-    else if (e.key === 'k' || e.key === 'ArrowUp') {
-      if (!rows.length) return;
-      e.preventDefault();
-      cur = Math.max(cur - 1, 0);
-      select(cur);
+    injectJ2000();
+    function loadEditor(fn) {
+      if (window.__editor) {
+        fn();
+        return;
+      }
+      const s = document.createElement("script");
+      const isPost = !!document.querySelector(".post-content");
+      s.src = (isPost ? "../" : "") + "assets/js/editor.js";
+      s.onload = fn;
+      document.head.appendChild(s);
     }
-    // Enter — open selected entry
-    else if (e.key === 'Enter' && cur >= 0) {
-      var link = rows[cur].querySelector('a');
-      if (link) link.click();
-    }
-    // ArrowLeft — prev (newer) post
-    else if (e.key === 'ArrowLeft') {
-      var prev = document.querySelector('.post-nav .prev');
-      if (prev) { e.preventDefault(); prev.click(); }
-    }
-    // ArrowRight — next (older) post
-    else if (e.key === 'ArrowRight') {
-      var next = document.querySelector('.post-nav .next');
-      if (next) { e.preventDefault(); next.click(); }
-    }
-    // Backspace — back to ~/log
-    else if (e.key === 'Backspace') {
-      var back = document.querySelector('.post-nav .back') ||
-                 document.querySelector('nav a[href*="index"]');
-      if (back) { e.preventDefault(); back.click(); }
-    }
-    // n — new entry (index page only)
-    else if (e.key === 'n' && !document.querySelector('.post-content')) {
-      e.preventDefault();
-      loadEditor(function() { window.__editor.newEntry(); });
-    }
-    // e — edit entry (post page or selected index row)
-    else if (e.key === 'e') {
-      var slug = document.querySelector('.post-content') ? getCurrentSlug() : getSelectedSlug();
-      if (slug) {
-        e.preventDefault();
-        loadEditor(function() { window.__editor.editEntry(slug); });
+    const rows = document.querySelectorAll(
+      ".ls-table tbody tr:not(.ls-group-year):not(.ls-group-month)"
+    );
+    let cur = -1;
+    function select(i) {
+      rows.forEach((r) => r.classList.remove("selected"));
+      if (i >= 0 && i < rows.length) {
+        rows[i].classList.add("selected");
+        rows[i].scrollIntoView({ behavior: "smooth", block: "nearest" });
       }
     }
-    // d — delete entry (index page, with selection)
-    else if (e.key === 'd' && !document.querySelector('.post-content')) {
-      var slug = getSelectedSlug();
-      if (slug) {
-        e.preventDefault();
-        loadEditor(function() { window.__editor.deleteEntry(slug); });
-      }
+    function getSelectedSlug() {
+      if (cur < 0 || !rows[cur]) return null;
+      const link = rows[cur].querySelector("a");
+      if (!link) return null;
+      const m = link.getAttribute("href")?.match(/posts\/([^.]+)\.html/);
+      return m ? m[1] : null;
     }
-  });
-
-  // --- viz module registry ---
-  window.__vizModules = window.__vizModules || {};
-  document.querySelectorAll('.viz-embed[data-viz]').forEach(function(el) {
-    var mod = window.__vizModules[el.dataset.viz];
-    if (mod) mod(el);
-  });
-
+    function getCurrentSlug() {
+      const m = location.pathname.match(/posts\/([^.]+)\.html/);
+      return m ? m[1] : null;
+    }
+    document.addEventListener("keydown", (e) => {
+      const target = e.target;
+      if (target.tagName === "INPUT" || target.tagName === "TEXTAREA") return;
+      if (document.querySelector(".editor-overlay")) return;
+      if (e.key === "j" || e.key === "ArrowDown") {
+        if (!rows.length) return;
+        e.preventDefault();
+        cur = Math.min(cur + 1, rows.length - 1);
+        select(cur);
+      } else if (e.key === "k" || e.key === "ArrowUp") {
+        if (!rows.length) return;
+        e.preventDefault();
+        cur = Math.max(cur - 1, 0);
+        select(cur);
+      } else if (e.key === "Enter" && cur >= 0) {
+        const link = rows[cur].querySelector("a");
+        if (link) link.click();
+      } else if (e.key === "ArrowLeft") {
+        const prev = document.querySelector(".post-nav .prev");
+        if (prev) {
+          e.preventDefault();
+          prev.click();
+        }
+      } else if (e.key === "ArrowRight") {
+        const next = document.querySelector(".post-nav .next");
+        if (next) {
+          e.preventDefault();
+          next.click();
+        }
+      } else if (e.key === "Backspace") {
+        const back = document.querySelector(".post-nav .back") ?? document.querySelector('nav a[href*="index"]');
+        if (back) {
+          e.preventDefault();
+          back.click();
+        }
+      } else if (e.key === "n" && !document.querySelector(".post-content")) {
+        e.preventDefault();
+        loadEditor(() => window.__editor?.newEntry());
+      } else if (e.key === "e") {
+        const slug = document.querySelector(".post-content") ? getCurrentSlug() : getSelectedSlug();
+        if (slug) {
+          e.preventDefault();
+          loadEditor(() => window.__editor?.editEntry(slug));
+        }
+      } else if (e.key === "d" && !document.querySelector(".post-content")) {
+        const slug = getSelectedSlug();
+        if (slug) {
+          e.preventDefault();
+          loadEditor(() => window.__editor?.deleteEntry(slug));
+        }
+      }
+    });
+    window.__vizModules = window.__vizModules || {};
+    document.querySelectorAll(".viz-embed[data-viz]").forEach((el) => {
+      const mod = window.__vizModules[el.dataset.viz ?? ""];
+      if (mod) mod(el);
+    });
+  })();
 })();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,29 @@
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.strict,
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      'no-var': 'error',
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_' },
+      ],
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'warn',
+    },
+  },
+  {
+    ignores: ['assets/js/**', 'node_modules/**'],
+  },
+);

--- a/index.html
+++ b/index.html
@@ -1,23 +1,22 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>log</title>
-  <link rel="stylesheet" href="assets/css/style.css">
-</head>
-<body>
-  <header>
-    <pre class="logo" aria-hidden="true">log</pre>
-    <p class="tagline">spoken words &amp; waypoints</p>
-  </header>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>log</title>
+    <link rel="stylesheet" href="assets/css/style.css" />
+  </head>
+  <body>
+    <header>
+      <pre class="logo" aria-hidden="true">log</pre>
+      <p class="tagline">spoken words &amp; waypoints</p>
+    </header>
 
-  <div class="shell-layout">
-
-    <!-- LEFT: project tree -->
-    <aside class="tree-panel">
-      <p class="panel-header">~/projects $ tree</p>
-<pre class="tree-listing">.
+    <div class="shell-layout">
+      <!-- LEFT: project tree -->
+      <aside class="tree-panel">
+        <p class="panel-header">~/projects $ tree</p>
+        <pre class="tree-listing">.
 ├── <a href="#" class="tree-dir">ground-nav-drone/</a>
 │   ├── jetson-thor
 │   ├── multi-cam
@@ -35,76 +34,100 @@
     └── d3-charts
 
 3 directories, 12 items</pre>
-    </aside>
+      </aside>
 
-    <!-- RIGHT: post listing (ls -lt style) -->
-    <main class="ls-panel">
-      <p class="panel-header">~/log $ ls -lt</p>
-      <table class="ls-table">
-        <thead>
-          <tr>
-            <th>date</th>
-            <th>type</th>
-            <th>entry</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr class="ls-group-year"><td colspan="3">2026</td></tr>
-          <tr class="ls-group-month"><td colspan="3">february</td></tr>
-          <!-- post-row -->
-          <tr class="spoken">
-            <td class="ls-date" data-date="2026-02-21">21</td>
-            <td class="ls-type spoken">spkn</td>
-            <td><a href="posts/entry-number-one.html">entry-number-one</a> <span class="ls-desc">— Hello, world, of course, more things to come.</span></td>
-          </tr>
-          <!-- /post-row -->
-          <!-- post-row -->
-          <tr class="spoken">
-            <td class="ls-date" data-date="2026-02-21">21</td>
-            <td class="ls-type spoken">spkn</td>
-            <td><a href="posts/test-drone-nav.html">test-drone-nav</a> <span class="ls-desc">— lorem ipsum drone navigation test post</span></td>
-          </tr>
-          <!-- /post-row -->
-          <!-- post-row -->
-          <tr class="written">
-            <td class="ls-date" data-date="2026-02-20">20</td>
-            <td class="ls-type written">writ</td>
-            <td><a href="posts/test-pension-data.html">test-pension-data</a> <span class="ls-desc">— lorem ipsum pension analysis test post</span></td>
-          </tr>
-          <!-- /post-row -->
-          <!-- post-row -->
-          <tr class="spoken">
-            <td class="ls-date" data-date="2026-02-19">19</td>
-            <td class="ls-type spoken">spkn</td>
-            <td><a href="posts/test-mtg-bot.html">test-mtg-bot</a> <span class="ls-desc">— lorem ipsum mtg reinforcement learning test post</span></td>
-          </tr>
-          <!-- /post-row -->
-          <!-- post-row -->
-          <tr class="written">
-            <td class="ls-date" data-date="2026-02-19">19</td>
-            <td class="ls-type written">writ</td>
-            <td><a href="posts/test-wasm-viz.html">test-wasm-viz</a> <span class="ls-desc">— lorem ipsum wasm visualization test post</span></td>
-          </tr>
-          <!-- /post-row -->
-          <!-- post-row -->
-          <tr class="spoken">
-            <td class="ls-date" data-date="2026-02-18">18</td>
-            <td class="ls-type spoken">spkn</td>
-            <td><a href="posts/hello-world.html">hello-world</a> <span class="ls-desc">— first entry, why spoken word, what's coming</span></td>
-          </tr>
-          <!-- /post-row -->
-        </tbody>
-      </table>
-      <p class="ls-count">6 entries</p>
-    </main>
+      <!-- RIGHT: post listing (ls -lt style) -->
+      <main class="ls-panel">
+        <p class="panel-header">~/log $ ls -lt</p>
+        <table class="ls-table">
+          <thead>
+            <tr>
+              <th>date</th>
+              <th>type</th>
+              <th>entry</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="ls-group-year">
+              <td colspan="3">2026</td>
+            </tr>
+            <tr class="ls-group-month">
+              <td colspan="3">february</td>
+            </tr>
+            <!-- post-row -->
+            <tr class="spoken">
+              <td class="ls-date" data-date="2026-02-21">21</td>
+              <td class="ls-type spoken">spkn</td>
+              <td>
+                <a href="posts/entry-number-one.html">entry-number-one</a>
+                <span class="ls-desc">— Hello, world, of course, more things to come.</span>
+              </td>
+            </tr>
+            <!-- /post-row -->
+            <!-- post-row -->
+            <tr class="spoken">
+              <td class="ls-date" data-date="2026-02-21">21</td>
+              <td class="ls-type spoken">spkn</td>
+              <td>
+                <a href="posts/test-drone-nav.html">test-drone-nav</a>
+                <span class="ls-desc">— lorem ipsum drone navigation test post</span>
+              </td>
+            </tr>
+            <!-- /post-row -->
+            <!-- post-row -->
+            <tr class="written">
+              <td class="ls-date" data-date="2026-02-20">20</td>
+              <td class="ls-type written">writ</td>
+              <td>
+                <a href="posts/test-pension-data.html">test-pension-data</a>
+                <span class="ls-desc">— lorem ipsum pension analysis test post</span>
+              </td>
+            </tr>
+            <!-- /post-row -->
+            <!-- post-row -->
+            <tr class="spoken">
+              <td class="ls-date" data-date="2026-02-19">19</td>
+              <td class="ls-type spoken">spkn</td>
+              <td>
+                <a href="posts/test-mtg-bot.html">test-mtg-bot</a>
+                <span class="ls-desc">— lorem ipsum mtg reinforcement learning test post</span>
+              </td>
+            </tr>
+            <!-- /post-row -->
+            <!-- post-row -->
+            <tr class="written">
+              <td class="ls-date" data-date="2026-02-19">19</td>
+              <td class="ls-type written">writ</td>
+              <td>
+                <a href="posts/test-wasm-viz.html">test-wasm-viz</a>
+                <span class="ls-desc">— lorem ipsum wasm visualization test post</span>
+              </td>
+            </tr>
+            <!-- /post-row -->
+            <!-- post-row -->
+            <tr class="spoken">
+              <td class="ls-date" data-date="2026-02-18">18</td>
+              <td class="ls-type spoken">spkn</td>
+              <td>
+                <a href="posts/hello-world.html">hello-world</a>
+                <span class="ls-desc">— first entry, why spoken word, what's coming</span>
+              </td>
+            </tr>
+            <!-- /post-row -->
+          </tbody>
+        </table>
+        <p class="ls-count">6 entries</p>
+      </main>
+    </div>
 
-  </div>
+    <footer>
+      <p class="vim-hint">
+        j/k ↑/↓ navigate · enter open · n new · e edit · d delete ·
+        <a href="https://vim.rtorr.com/" target="_blank" rel="noopener">vim?</a>
+      </p>
+      <p class="footer-eof">EOF</p>
+    </footer>
 
-  <footer>
-    <p class="vim-hint">j/k ↑/↓ navigate · enter open · n new · e edit · d delete · <a href="https://vim.rtorr.com/" target="_blank" rel="noopener">vim?</a></p>
-    <p class="footer-eof">EOF</p>
-  </footer>
-
-  <script src="assets/js/main.js"></script>
-</body>
+    <script src="assets/js/main.js"></script>
+  </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3945 @@
+{
+  "name": "vimsite",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vimsite",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@eslint/js": "^9.0.0",
+        "esbuild": "^0.24.0",
+        "eslint": "^9.0.0",
+        "husky": "^9.0.0",
+        "lint-staged": "^15.0.0",
+        "prettier": "^3.4.0",
+        "stylelint": "^16.0.0",
+        "stylelint-config-standard": "^37.0.0",
+        "typescript": "^5.7.0",
+        "typescript-eslint": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cacheable/memory": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.7.tgz",
+      "integrity": "sha512-RbxnxAMf89Tp1dLhXMS7ceft/PGsDl1Ip7T20z5nZ+pwIAsQ1p2izPjVG69oCLv/jfQ7HDPHTWK0c9rcAWXN3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.3.3",
+        "@keyv/bigmap": "^1.3.0",
+        "hookified": "^1.14.0",
+        "keyv": "^5.5.5"
+      }
+    },
+    "node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/memory/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.3.4.tgz",
+      "integrity": "sha512-knwKUJEYgIfwShABS1BX6JyJJTglAFcEU7EXqzTdiGCXur4voqkiJkdgZIQtWNFhynzDWERcTYv/sETMu3uJWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.3.0",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/utils/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.28.tgz",
+      "integrity": "sha512-1NRf1CUBjnr3K7hu8BLxjQrKCxEe8FP/xmPTenAxCRZWVLbmGotkFvG9mfNpjA6k7Bw1bw4BilZq9cu19RA5pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/media-query-list-parser": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz",
+      "integrity": "sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/selector-specificity": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
+      "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      }
+    },
+    "node_modules/@dual-bundle/import-meta-resolve": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.2.1.tgz",
+      "integrity": "sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/JounQin"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.3",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
+      "integrity": "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.0.tgz",
+      "integrity": "sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/type-utils": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.56.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.0.tgz",
+      "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.0.tgz",
+      "integrity": "sha512-M3rnyL1vIQOMeWxTWIW096/TtVP+8W3p/XnaFflhmcFp+U4zlxUxWj4XwNs6HbDeTtN4yun0GNTTDBw/SvufKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.56.0",
+        "@typescript-eslint/types": "^8.56.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.0.tgz",
+      "integrity": "sha512-7UiO/XwMHquH+ZzfVCfUNkIXlp/yQjjnlYUyYz7pfvlK3/EyyN6BK+emDmGNyQLBtLGaYrTAI6KOw8tFucWL2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.0.tgz",
+      "integrity": "sha512-bSJoIIt4o3lKXD3xmDh9chZcjCz5Lk8xS7Rxn+6l5/pKrDpkCwtQNQQwZ2qRPk7TkUYhrq3WPIHXOXlbXP0itg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.0.tgz",
+      "integrity": "sha512-qX2L3HWOU2nuDs6GzglBeuFXviDODreS58tLY/BALPC7iu3Fa+J7EOTwnX9PdNBxUI7Uh0ntP0YWGnxCkXzmfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.0.tgz",
+      "integrity": "sha512-DBsLPs3GsWhX5HylbP9HNG15U0bnwut55Lx12bHB9MpXxQ+R5GC8MwQe+N1UFXxAeQDvEsEDY6ZYwX03K7Z6HQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.0.tgz",
+      "integrity": "sha512-ex1nTUMWrseMltXUHmR2GAQ4d+WjkZCT4f+4bVsps8QEdh0vlBsaCokKTPlnqBFqqGaxilDNJG7b8dolW2m43Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.56.0",
+        "@typescript-eslint/tsconfig-utils": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
+        "debug": "^4.4.3",
+        "minimatch": "^9.0.5",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.0.tgz",
+      "integrity": "sha512-RZ3Qsmi2nFGsS+n+kjLAYDPVlrzf7UhTffrDIKr+h2yzAlYP/y5ZulU0yeDEPItos2Ph46JAL5P/On3pe7kDIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.0.tgz",
+      "integrity": "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacheable": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.2.tgz",
+      "integrity": "sha512-w+ZuRNmex9c1TR9RcsxbfTKCjSL0rh1WA5SABbrWprIHeNBdmyQLSYonlDy9gpD+63XT8DgZ/wNh1Smvc9WnJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/memory": "^2.0.7",
+        "@cacheable/utils": "^2.3.3",
+        "hookified": "^1.15.0",
+        "keyv": "^5.5.5",
+        "qified": "^0.6.0"
+      }
+    },
+    "node_modules/cacheable/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colord": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-functions-list": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
+      "integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.3.tgz",
+      "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.39.3",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-prefix": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globjoin": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+      "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hashery": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.0.tgz",
+      "integrity": "sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.14.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-tags": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
+      "integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/known-css-properties": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
+      "integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lint-staged": {
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz",
+      "integrity": "sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^13.1.0",
+        "debug": "^4.4.0",
+        "execa": "^8.0.1",
+        "lilconfig": "^3.1.3",
+        "listr2": "^8.2.5",
+        "micromatch": "^4.0.8",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.7.0"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz",
+      "integrity": "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^4.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/mathml-tag-names": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
+      "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/meow": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-resolve-nested-selector": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz",
+      "integrity": "sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss-safe-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
+      "integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.31"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qified": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.6.0.tgz",
+      "integrity": "sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.14.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stylelint": {
+      "version": "16.26.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz",
+      "integrity": "sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.19",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/media-query-list-parser": "^4.0.3",
+        "@csstools/selector-specificity": "^5.0.0",
+        "@dual-bundle/import-meta-resolve": "^4.2.1",
+        "balanced-match": "^2.0.0",
+        "colord": "^2.9.3",
+        "cosmiconfig": "^9.0.0",
+        "css-functions-list": "^3.2.3",
+        "css-tree": "^3.1.0",
+        "debug": "^4.4.3",
+        "fast-glob": "^3.3.3",
+        "fastest-levenshtein": "^1.0.16",
+        "file-entry-cache": "^11.1.1",
+        "global-modules": "^2.0.0",
+        "globby": "^11.1.0",
+        "globjoin": "^0.1.4",
+        "html-tags": "^3.3.1",
+        "ignore": "^7.0.5",
+        "imurmurhash": "^0.1.4",
+        "is-plain-object": "^5.0.0",
+        "known-css-properties": "^0.37.0",
+        "mathml-tag-names": "^2.1.3",
+        "meow": "^13.2.0",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.5.6",
+        "postcss-resolve-nested-selector": "^0.1.6",
+        "postcss-safe-parser": "^7.0.1",
+        "postcss-selector-parser": "^7.1.0",
+        "postcss-value-parser": "^4.2.0",
+        "resolve-from": "^5.0.0",
+        "string-width": "^4.2.3",
+        "supports-hyperlinks": "^3.2.0",
+        "svg-tags": "^1.0.0",
+        "table": "^6.9.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "bin": {
+        "stylelint": "bin/stylelint.mjs"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/stylelint-config-recommended": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-15.0.0.tgz",
+      "integrity": "sha512-9LejMFsat7L+NXttdHdTq94byn25TD+82bzGRiV1Pgasl99pWnwipXS5DguTpp3nP1XjvLXVnEJIuYBfsRjRkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^16.13.0"
+      }
+    },
+    "node_modules/stylelint-config-standard": {
+      "version": "37.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-37.0.0.tgz",
+      "integrity": "sha512-+6eBlbSTrOn/il2RlV0zYGQwRTkr+WtzuVSs1reaWGObxnxLpbcspCUYajVQHonVfxVw2U+h42azGhrBvcg8OA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "stylelint-config-recommended": "^15.0.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^16.13.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stylelint/node_modules/balanced-match": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
+      "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stylelint/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stylelint/node_modules/file-entry-cache": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
+      "integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^6.1.20"
+      }
+    },
+    "node_modules/stylelint/node_modules/flat-cache": {
+      "version": "6.1.20",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.20.tgz",
+      "integrity": "sha512-AhHYqwvN62NVLp4lObVXGVluiABTHapoB57EyegZVmazN+hhGhLTn3uZbOofoTw4DSDvVCadzzyChXhOAvy8uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cacheable": "^2.3.2",
+        "flatted": "^3.3.3",
+        "hookified": "^1.15.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/stylelint/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stylelint/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stylelint/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stylelint/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/svg-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
+      "dev": true
+    },
+    "node_modules/table": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/table/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/table/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.0.tgz",
+      "integrity": "sha512-c7toRLrotJ9oixgdW7liukZpsnq5CZ7PuKztubGYlNppuTqhIoWfhgHo/7EU0v06gS2l/x0i2NEFK1qMIf0rIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.56.0",
+        "@typescript-eslint/parser": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "vimsite",
+  "version": "1.0.0",
+  "private": true,
+  "description": "steven's log — spoken words & waypoints",
+  "scripts": {
+    "build": "esbuild src/main.ts --outfile=assets/js/main.js --bundle=false --format=iife --target=es2020 && esbuild src/editor.ts --outfile=assets/js/editor.js --bundle=false --format=iife --target=es2020",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src/ && stylelint 'assets/css/**/*.css' && tsc --noEmit",
+    "lint:fix": "eslint src/ --fix && stylelint 'assets/css/**/*.css' --fix",
+    "format": "prettier --write 'src/**/*.ts' 'assets/css/**/*.css' '*.html' 'posts/**/*.html'",
+    "format:check": "prettier --check 'src/**/*.ts' 'assets/css/**/*.css' '*.html' 'posts/**/*.html'",
+    "prepare": "husky"
+  },
+  "devDependencies": {
+    "esbuild": "^0.24.0",
+    "typescript": "^5.7.0",
+    "eslint": "^9.0.0",
+    "@eslint/js": "^9.0.0",
+    "typescript-eslint": "^8.0.0",
+    "stylelint": "^16.0.0",
+    "stylelint-config-standard": "^37.0.0",
+    "prettier": "^3.4.0",
+    "husky": "^9.0.0",
+    "lint-staged": "^15.0.0"
+  },
+  "lint-staged": {
+    "src/**/*.ts": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "assets/css/**/*.css": [
+      "stylelint --fix",
+      "prettier --write"
+    ],
+    "*.html": [
+      "prettier --write"
+    ]
+  }
+}

--- a/posts/entry-number-one.html
+++ b/posts/entry-number-one.html
@@ -1,49 +1,47 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>entry-number-one — log</title>
-  <link rel="stylesheet" href="../assets/css/style.css">
-</head>
-<body>
-  <header>
-    <nav style="font-size: 0.8rem; color: var(--fg-dim);">
-      <a href="../index.html">~/log</a> / entry-number-one
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>entry-number-one — log</title>
+    <link rel="stylesheet" href="../assets/css/style.css" />
+  </head>
+  <body>
+    <header>
+      <nav style="font-size: 0.8rem; color: var(--fg-dim)">
+        <a href="../index.html">~/log</a> / entry-number-one
+      </nav>
+    </header>
+
+    <main class="post-content">
+      <div class="post-meta">
+        <time datetime="2026-02-21">2026-02-21</time>
+        <span class="post-type spoken">spoken</span>
+      </div>
+      <h1>entry-number-one</h1>
+
+      <div class="spoken-transcript">
+        <p class="spoken-label">transcribed via spokenly · lightly edited</p>
+
+        <p>Hello, world, of course, more things to come.</p>
+      </div>
+
+      <div class="post-tags">
+        <span class="tag">test</span>
+        <span class="tag">hellowq</span>
+      </div>
+    </main>
+
+    <nav class="post-nav">
+      <a class="back" href="../index.html">← ~/log</a>
+      <a class="next" href="test-drone-nav.html">test-drone-nav →</a>
     </nav>
-  </header>
 
-  <main class="post-content">
-    <div class="post-meta">
-      <time datetime="2026-02-21">2026-02-21</time>
-      <span class="post-type spoken">spoken</span>
-    </div>
-    <h1>entry-number-one</h1>
+    <footer>
+      <p class="vim-hint">← → between posts · backspace ~/log · e edit</p>
+      <p class="footer-eof">EOF</p>
+    </footer>
 
-    <div class="spoken-transcript">
-      <p class="spoken-label">transcribed via spokenly · lightly edited</p>
-
-      <p>
-        Hello, world, of course, more things to come.
-      </p>
-    </div>
-
-    <div class="post-tags">
-      <span class="tag">test</span>
-      <span class="tag">hellowq</span>
-    </div>
-  </main>
-
-  <nav class="post-nav">
-    <a class="back" href="../index.html">← ~/log</a>
-    <a class="next" href="test-drone-nav.html">test-drone-nav →</a>
-  </nav>
-
-  <footer>
-    <p class="vim-hint">← → between posts · backspace ~/log · e edit</p>
-    <p class="footer-eof">EOF</p>
-  </footer>
-
-  <script src="../assets/js/main.js"></script>
-</body>
+    <script src="../assets/js/main.js"></script>
+  </body>
 </html>

--- a/posts/hello-world.html
+++ b/posts/hello-world.html
@@ -1,84 +1,79 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>hello-world — log</title>
-  <link rel="stylesheet" href="../assets/css/style.css">
-</head>
-<body>
-  <header>
-    <nav style="font-size: 0.8rem; color: var(--fg-dim);">
-      <a href="../index.html">~/log</a> / hello-world
-    </nav>
-  </header>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>hello-world — log</title>
+    <link rel="stylesheet" href="../assets/css/style.css" />
+  </head>
+  <body>
+    <header>
+      <nav style="font-size: 0.8rem; color: var(--fg-dim)">
+        <a href="../index.html">~/log</a> / hello-world
+      </nav>
+    </header>
 
-  <main class="post-content">
-    <div class="post-meta">
-      <time datetime="2026-02-18">2026-02-18</time>
-      <span class="post-type spoken">spoken</span>
-    </div>
-    <h1>hello-world</h1>
+    <main class="post-content">
+      <div class="post-meta">
+        <time datetime="2026-02-18">2026-02-18</time>
+        <span class="post-type spoken">spoken</span>
+      </div>
+      <h1>hello-world</h1>
 
-    <div class="spoken-transcript">
-      <p class="spoken-label">transcribed via spokenly · lightly edited</p>
+      <div class="spoken-transcript">
+        <p class="spoken-label">transcribed via spokenly · lightly edited</p>
 
-      <p>
-        Alright, so... I've been meaning to do this for a while. I've got all
-        these projects going — the drone, the MTG bot, the pension thing — and
-        I realized I have no record of the thinking that goes into them. Just
-        code and commits.
-      </p>
+        <p>
+          Alright, so... I've been meaning to do this for a while. I've got all these projects going
+          — the drone, the MTG bot, the pension thing — and I realized I have no record of the
+          thinking that goes into them. Just code and commits.
+        </p>
 
-      <p>
-        The idea here is simple. I talk into Spokenly, it captures what I'm
-        saying with these Nvidia Parakeet models — which are honestly wild,
-        the accuracy is really solid — and then I do a light cleanup pass and
-        post it here. Spoken word as source material.
-      </p>
+        <p>
+          The idea here is simple. I talk into Spokenly, it captures what I'm saying with these
+          Nvidia Parakeet models — which are honestly wild, the accuracy is really solid — and then
+          I do a light cleanup pass and post it here. Spoken word as source material.
+        </p>
 
-      <p>
-        I like that it's messy. It's not a polished Medium post. It's closer
-        to a lab notebook than a blog. That's the vibe I want.
-      </p>
+        <p>
+          I like that it's messy. It's not a polished Medium post. It's closer to a lab notebook
+          than a blog. That's the vibe I want.
+        </p>
 
-      <p>
-        What's coming: I want to get some WebAssembly visualizations embedded
-        for the drone nav stuff. Like, imagine being able to show a factor
-        graph optimizing in real time in the browser. That's the dream. And
-        for the pension analysis, some D3 charts showing the funding gap over
-        time. Interactive stuff, not just screenshots.
-      </p>
+        <p>
+          What's coming: I want to get some WebAssembly visualizations embedded for the drone nav
+          stuff. Like, imagine being able to show a factor graph optimizing in real time in the
+          browser. That's the dream. And for the pension analysis, some D3 charts showing the
+          funding gap over time. Interactive stuff, not just screenshots.
+        </p>
 
-      <p>
-        Anyway, this is entry one. More soon.
-      </p>
-    </div>
+        <p>Anyway, this is entry one. More soon.</p>
+      </div>
 
-    <!-- viz embeds go here when ready -->
-    <!--
+      <!-- viz embeds go here when ready -->
+      <!--
     <div class="viz-embed" data-viz="drone-nav">
       <span class="viz-label">LIVE VIZ</span>
     </div>
     -->
 
-    <div class="post-tags">
-      <span class="tag">meta</span>
-      <span class="tag">drone</span>
-      <span class="tag">pension</span>
-    </div>
-  </main>
+      <div class="post-tags">
+        <span class="tag">meta</span>
+        <span class="tag">drone</span>
+        <span class="tag">pension</span>
+      </div>
+    </main>
 
-  <nav class="post-nav">
-    <a class="prev" href="test-wasm-viz.html">← test-wasm-viz</a>
-    <a class="back" href="../index.html">~/log</a>
-  </nav>
+    <nav class="post-nav">
+      <a class="prev" href="test-wasm-viz.html">← test-wasm-viz</a>
+      <a class="back" href="../index.html">~/log</a>
+    </nav>
 
-  <footer>
-    <p class="vim-hint">← → between posts · backspace ~/log · e edit</p>
-    <p class="footer-eof">EOF</p>
-  </footer>
+    <footer>
+      <p class="vim-hint">← → between posts · backspace ~/log · e edit</p>
+      <p class="footer-eof">EOF</p>
+    </footer>
 
-  <script src="../assets/js/main.js"></script>
-</body>
+    <script src="../assets/js/main.js"></script>
+  </body>
 </html>

--- a/posts/test-drone-nav.html
+++ b/posts/test-drone-nav.html
@@ -1,66 +1,64 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>test-drone-nav — log</title>
-  <link rel="stylesheet" href="../assets/css/style.css">
-</head>
-<body>
-  <header>
-    <nav style="font-size: 0.8rem; color: var(--fg-dim);">
-      <a href="../index.html">~/log</a> / test-drone-nav
-    </nav>
-  </header>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>test-drone-nav — log</title>
+    <link rel="stylesheet" href="../assets/css/style.css" />
+  </head>
+  <body>
+    <header>
+      <nav style="font-size: 0.8rem; color: var(--fg-dim)">
+        <a href="../index.html">~/log</a> / test-drone-nav
+      </nav>
+    </header>
 
-  <main class="post-content">
-    <div class="post-meta">
-      <time datetime="2026-02-21">2026-02-21</time>
-      <span class="post-type spoken">spoken</span>
-    </div>
-    <h1>test-drone-nav</h1>
+    <main class="post-content">
+      <div class="post-meta">
+        <time datetime="2026-02-21">2026-02-21</time>
+        <span class="post-type spoken">spoken</span>
+      </div>
+      <h1>test-drone-nav</h1>
 
-    <div class="spoken-transcript">
-      <p class="spoken-label">transcribed via spokenly · lightly edited</p>
+      <div class="spoken-transcript">
+        <p class="spoken-label">transcribed via spokenly · lightly edited</p>
 
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-        commodo consequat.
-      </p>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt
+          ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+          ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </p>
 
-      <p>
-        Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
-        dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
-        proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-      </p>
+        <p>
+          Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+          nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+          deserunt mollit anim id est laborum.
+        </p>
 
-      <p>
-        Curabitur pretium tincidunt lacus. Nulla gravida orci a odio. Nullam
-        varius, turpis et commodo pharetra, est eros bibendum elit, nec luctus
-        magna felis sollicitudin mauris.
-      </p>
-    </div>
+        <p>
+          Curabitur pretium tincidunt lacus. Nulla gravida orci a odio. Nullam varius, turpis et
+          commodo pharetra, est eros bibendum elit, nec luctus magna felis sollicitudin mauris.
+        </p>
+      </div>
 
-    <div class="post-tags">
-      <span class="tag">drone</span>
-      <span class="tag">nav</span>
-      <span class="tag">test</span>
-    </div>
-  </main>
+      <div class="post-tags">
+        <span class="tag">drone</span>
+        <span class="tag">nav</span>
+        <span class="tag">test</span>
+      </div>
+    </main>
 
     <nav class="post-nav">
-    <a class="prev" href="entry-number-one.html">← entry-number-one</a>
-    <a class="back" href="../index.html">~/log</a>
-    <a class="next" href="test-pension-data.html">test-pension-data →</a>
-  </nav>
+      <a class="prev" href="entry-number-one.html">← entry-number-one</a>
+      <a class="back" href="../index.html">~/log</a>
+      <a class="next" href="test-pension-data.html">test-pension-data →</a>
+    </nav>
 
-  <footer>
-    <p class="vim-hint">← → between posts · backspace ~/log · e edit</p>
-    <p class="footer-eof">EOF</p>
-  </footer>
+    <footer>
+      <p class="vim-hint">← → between posts · backspace ~/log · e edit</p>
+      <p class="footer-eof">EOF</p>
+    </footer>
 
-  <script src="../assets/js/main.js"></script>
-</body>
+    <script src="../assets/js/main.js"></script>
+  </body>
 </html>

--- a/posts/test-mtg-bot.html
+++ b/posts/test-mtg-bot.html
@@ -1,61 +1,59 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>test-mtg-bot — log</title>
-  <link rel="stylesheet" href="../assets/css/style.css">
-</head>
-<body>
-  <header>
-    <nav style="font-size: 0.8rem; color: var(--fg-dim);">
-      <a href="../index.html">~/log</a> / test-mtg-bot
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>test-mtg-bot — log</title>
+    <link rel="stylesheet" href="../assets/css/style.css" />
+  </head>
+  <body>
+    <header>
+      <nav style="font-size: 0.8rem; color: var(--fg-dim)">
+        <a href="../index.html">~/log</a> / test-mtg-bot
+      </nav>
+    </header>
+
+    <main class="post-content">
+      <div class="post-meta">
+        <time datetime="2026-02-19">2026-02-19</time>
+        <span class="post-type spoken">spoken</span>
+      </div>
+      <h1>test-mtg-bot</h1>
+
+      <div class="spoken-transcript">
+        <p class="spoken-label">transcribed via spokenly · lightly edited</p>
+
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque habitant morbi
+          tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam,
+          feugiat vitae, ultricies eget, tempor sit amet, ante.
+        </p>
+
+        <p>
+          Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris
+          placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum
+          erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi.
+        </p>
+      </div>
+
+      <div class="post-tags">
+        <span class="tag">mtg</span>
+        <span class="tag">rl</span>
+        <span class="tag">test</span>
+      </div>
+    </main>
+
+    <nav class="post-nav">
+      <a class="prev" href="test-pension-data.html">← test-pension-data</a>
+      <a class="back" href="../index.html">~/log</a>
+      <a class="next" href="test-wasm-viz.html">test-wasm-viz →</a>
     </nav>
-  </header>
 
-  <main class="post-content">
-    <div class="post-meta">
-      <time datetime="2026-02-19">2026-02-19</time>
-      <span class="post-type spoken">spoken</span>
-    </div>
-    <h1>test-mtg-bot</h1>
+    <footer>
+      <p class="vim-hint">← → between posts · backspace ~/log · e edit</p>
+      <p class="footer-eof">EOF</p>
+    </footer>
 
-    <div class="spoken-transcript">
-      <p class="spoken-label">transcribed via spokenly · lightly edited</p>
-
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque
-        habitant morbi tristique senectus et netus et malesuada fames ac turpis
-        egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor
-        sit amet, ante.
-      </p>
-
-      <p>
-        Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae
-        est. Mauris placerat eleifend leo. Quisque sit amet est et sapien
-        ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo
-        vitae, ornare sit amet, wisi.
-      </p>
-    </div>
-
-    <div class="post-tags">
-      <span class="tag">mtg</span>
-      <span class="tag">rl</span>
-      <span class="tag">test</span>
-    </div>
-  </main>
-
-  <nav class="post-nav">
-    <a class="prev" href="test-pension-data.html">← test-pension-data</a>
-    <a class="back" href="../index.html">~/log</a>
-    <a class="next" href="test-wasm-viz.html">test-wasm-viz →</a>
-  </nav>
-
-  <footer>
-    <p class="vim-hint">← → between posts · backspace ~/log · e edit</p>
-    <p class="footer-eof">EOF</p>
-  </footer>
-
-  <script src="../assets/js/main.js"></script>
-</body>
+    <script src="../assets/js/main.js"></script>
+  </body>
 </html>

--- a/posts/test-pension-data.html
+++ b/posts/test-pension-data.html
@@ -1,75 +1,73 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>test-pension-data — log</title>
-  <link rel="stylesheet" href="../assets/css/style.css">
-</head>
-<body>
-  <header>
-    <nav style="font-size: 0.8rem; color: var(--fg-dim);">
-      <a href="../index.html">~/log</a> / test-pension-data
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>test-pension-data — log</title>
+    <link rel="stylesheet" href="../assets/css/style.css" />
+  </head>
+  <body>
+    <header>
+      <nav style="font-size: 0.8rem; color: var(--fg-dim)">
+        <a href="../index.html">~/log</a> / test-pension-data
+      </nav>
+    </header>
+
+    <main class="post-content">
+      <div class="post-meta">
+        <time datetime="2026-02-20">2026-02-20</time>
+        <span class="post-type written">written</span>
+      </div>
+      <h1>test-pension-data</h1>
+
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus lacinia odio vitae
+        vestibulum vestibulum. Cras vehicula, mi eget laoreet venenatis, sem nisi accumsan nunc, vel
+        blandit dolor purus non enim.
+      </p>
+
+      <h2>section header example</h2>
+
+      <p>
+        Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui.
+        Donec ullamcorper nulla non metus auctor fringilla. Morbi leo risus, porta ac consectetur
+        ac, vestibulum at eros. Nullam quis risus eget urna mollis ornare vel eu leo.
+      </p>
+
+      <p>
+        Maecenas faucibus mollis interdum. Cras mattis consectetur purus sit amet fermentum. Aenean
+        lacinia bibendum nulla sed consectetur. Integer posuere erat a ante venenatis dapibus
+        posuere velit aliquet.
+      </p>
+
+      <blockquote>
+        This is a blockquote to test how quotes render in the terminal style. Etiam porta sem
+        malesuada magna mollis euismod.
+      </blockquote>
+
+      <p>
+        Sed posuere consectetur est at lobortis. Fusce dapibus, tellus ac cursus commodo, tortor
+        mauris condimentum nibh, ut fermentum massa justo sit amet risus.
+      </p>
+
+      <div class="post-tags">
+        <span class="tag">pension</span>
+        <span class="tag">data</span>
+        <span class="tag">test</span>
+      </div>
+    </main>
+
+    <nav class="post-nav">
+      <a class="prev" href="test-drone-nav.html">← test-drone-nav</a>
+      <a class="back" href="../index.html">~/log</a>
+      <a class="next" href="test-mtg-bot.html">test-mtg-bot →</a>
     </nav>
-  </header>
 
-  <main class="post-content">
-    <div class="post-meta">
-      <time datetime="2026-02-20">2026-02-20</time>
-      <span class="post-type written">written</span>
-    </div>
-    <h1>test-pension-data</h1>
+    <footer>
+      <p class="vim-hint">← → between posts · backspace ~/log · e edit</p>
+      <p class="footer-eof">EOF</p>
+    </footer>
 
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus lacinia
-      odio vitae vestibulum vestibulum. Cras vehicula, mi eget laoreet venenatis,
-      sem nisi accumsan nunc, vel blandit dolor purus non enim.
-    </p>
-
-    <h2>section header example</h2>
-
-    <p>
-      Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
-      Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.
-      Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Nullam
-      quis risus eget urna mollis ornare vel eu leo.
-    </p>
-
-    <p>
-      Maecenas faucibus mollis interdum. Cras mattis consectetur purus sit amet
-      fermentum. Aenean lacinia bibendum nulla sed consectetur. Integer posuere
-      erat a ante venenatis dapibus posuere velit aliquet.
-    </p>
-
-    <blockquote>
-      This is a blockquote to test how quotes render in the terminal style.
-      Etiam porta sem malesuada magna mollis euismod.
-    </blockquote>
-
-    <p>
-      Sed posuere consectetur est at lobortis. Fusce dapibus, tellus ac cursus
-      commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit
-      amet risus.
-    </p>
-
-    <div class="post-tags">
-      <span class="tag">pension</span>
-      <span class="tag">data</span>
-      <span class="tag">test</span>
-    </div>
-  </main>
-
-  <nav class="post-nav">
-    <a class="prev" href="test-drone-nav.html">← test-drone-nav</a>
-    <a class="back" href="../index.html">~/log</a>
-    <a class="next" href="test-mtg-bot.html">test-mtg-bot →</a>
-  </nav>
-
-  <footer>
-    <p class="vim-hint">← → between posts · backspace ~/log · e edit</p>
-    <p class="footer-eof">EOF</p>
-  </footer>
-
-  <script src="../assets/js/main.js"></script>
-</body>
+    <script src="../assets/js/main.js"></script>
+  </body>
 </html>

--- a/posts/test-wasm-viz.html
+++ b/posts/test-wasm-viz.html
@@ -1,75 +1,74 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>test-wasm-viz — log</title>
-  <link rel="stylesheet" href="../assets/css/style.css">
-</head>
-<body>
-  <header>
-    <nav style="font-size: 0.8rem; color: var(--fg-dim);">
-      <a href="../index.html">~/log</a> / test-wasm-viz
-    </nav>
-  </header>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>test-wasm-viz — log</title>
+    <link rel="stylesheet" href="../assets/css/style.css" />
+  </head>
+  <body>
+    <header>
+      <nav style="font-size: 0.8rem; color: var(--fg-dim)">
+        <a href="../index.html">~/log</a> / test-wasm-viz
+      </nav>
+    </header>
 
-  <main class="post-content">
-    <div class="post-meta">
-      <time datetime="2026-02-19">2026-02-19</time>
-      <span class="post-type written">written</span>
-    </div>
-    <h1>test-wasm-viz</h1>
+    <main class="post-content">
+      <div class="post-meta">
+        <time datetime="2026-02-19">2026-02-19</time>
+        <span class="post-type written">written</span>
+      </div>
+      <h1>test-wasm-viz</h1>
 
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam
-      tincidunt mauris eu risus. Vestibulum auctor dapibus neque.
-    </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt mauris eu risus.
+        Vestibulum auctor dapibus neque.
+      </p>
 
-    <h2>code block example</h2>
+      <h2>code block example</h2>
 
-    <pre><code>fn main() {
+      <pre><code>fn main() {
     let graph = FactorGraph::new();
     graph.add_variable("x0", Pose2::identity());
     graph.add_factor(PriorFactor::new("x0", prior_mean));
     graph.optimize();
 }</code></pre>
 
-    <p>
-      Nunc dignissim risus id metus. Cras ornare tristique elit. Vivamus
-      vestibulum ntulla nec ante. Praesent placerat risus quis eros. Fusce
-      pellentesque suscipit nibh. Integer vitae libero ac risus egestas
-      placerat.
-    </p>
+      <p>
+        Nunc dignissim risus id metus. Cras ornare tristique elit. Vivamus vestibulum ntulla nec
+        ante. Praesent placerat risus quis eros. Fusce pellentesque suscipit nibh. Integer vitae
+        libero ac risus egestas placerat.
+      </p>
 
-    <!-- viz embed placeholder -->
-    <div class="viz-embed" data-viz="test-viz">
-      <span class="viz-label">LIVE VIZ</span>
-    </div>
+      <!-- viz embed placeholder -->
+      <div class="viz-embed" data-viz="test-viz">
+        <span class="viz-label">LIVE VIZ</span>
+      </div>
 
-    <p>
-      Vestibulum commodo felis quis tortor. Ut aliquam sollicitudin leo.
-      Cras iaculis ultricies nulla. Donec quis dui at dolor tempor interdum.
-    </p>
+      <p>
+        Vestibulum commodo felis quis tortor. Ut aliquam sollicitudin leo. Cras iaculis ultricies
+        nulla. Donec quis dui at dolor tempor interdum.
+      </p>
 
-    <div class="post-tags">
-      <span class="tag">wasm</span>
-      <span class="tag">viz</span>
-      <span class="tag">rust</span>
-      <span class="tag">test</span>
-    </div>
-  </main>
+      <div class="post-tags">
+        <span class="tag">wasm</span>
+        <span class="tag">viz</span>
+        <span class="tag">rust</span>
+        <span class="tag">test</span>
+      </div>
+    </main>
 
-  <nav class="post-nav">
-    <a class="prev" href="test-mtg-bot.html">← test-mtg-bot</a>
-    <a class="back" href="../index.html">~/log</a>
-    <a class="next" href="hello-world.html">hello-world →</a>
-  </nav>
+    <nav class="post-nav">
+      <a class="prev" href="test-mtg-bot.html">← test-mtg-bot</a>
+      <a class="back" href="../index.html">~/log</a>
+      <a class="next" href="hello-world.html">hello-world →</a>
+    </nav>
 
-  <footer>
-    <p class="vim-hint">← → between posts · backspace ~/log · e edit</p>
-    <p class="footer-eof">EOF</p>
-  </footer>
+    <footer>
+      <p class="vim-hint">← → between posts · backspace ~/log · e edit</p>
+      <p class="footer-eof">EOF</p>
+    </footer>
 
-  <script src="../assets/js/main.js"></script>
-</body>
+    <script src="../assets/js/main.js"></script>
+  </body>
 </html>

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,0 +1,827 @@
+/* log — editor.ts — lazy-loaded, auth-gated */
+
+// === Interfaces ===
+
+interface GitHubRef {
+  object: { sha: string };
+}
+
+interface GitHubCommit {
+  tree: { sha: string };
+  sha: string;
+}
+
+interface GitHubTree {
+  sha: string;
+}
+
+interface GitHubContent {
+  content: string;
+  sha: string;
+}
+
+interface FileEntry {
+  path: string;
+  content?: string;
+  delete?: boolean;
+}
+
+interface TreeEntry {
+  path: string;
+  mode: '100644';
+  type: 'blob';
+  sha?: string | null;
+  content?: string;
+}
+
+interface Post {
+  slug: string;
+  date: string;
+  type: PostType;
+  content: string;
+  tags: string[];
+  prevSlug: string | null;
+  nextSlug: string | null;
+}
+
+type PostGenerateOptions = Post;
+
+interface EditorSaveResult {
+  slug: string;
+  type: PostType;
+  content: string;
+  desc: string;
+  tags: string[];
+}
+
+interface EditorOptions {
+  mode: 'new' | 'edit';
+  slug?: string;
+  type?: PostType;
+  content?: string;
+  tags?: string[];
+  desc?: string;
+  onSave: (result: EditorSaveResult) => Promise<void>;
+}
+
+type PostType = 'spoken' | 'written';
+
+// === IIFE ===
+
+(function () {
+  'use strict';
+
+  const OWNER = 'RexGoliath1';
+  const REPO = 'vimsite';
+  const BRANCH = 'main';
+  const API = 'https://api.github.com/repos/' + OWNER + '/' + REPO;
+  const MONTHS = [
+    '',
+    'january',
+    'february',
+    'march',
+    'april',
+    'may',
+    'june',
+    'july',
+    'august',
+    'september',
+    'october',
+    'november',
+    'december',
+  ];
+
+  // ====== Helpers ======
+
+  function esc(s: string): string {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  function today(): string {
+    const d = new Date();
+    return (
+      d.getFullYear() +
+      '-' +
+      String(d.getMonth() + 1).padStart(2, '0') +
+      '-' +
+      String(d.getDate()).padStart(2, '0')
+    );
+  }
+
+  function slugify(t: string): string {
+    return t
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '')
+      .slice(0, 50);
+  }
+
+  function el(tag: string, cls?: string): HTMLElement {
+    const e = document.createElement(tag);
+    if (cls) e.className = cls;
+    return e;
+  }
+  // ====== Auth ======
+
+  function getToken(): string | null {
+    return localStorage.getItem('vimsite_token');
+  }
+
+  function setToken(t: string): void {
+    localStorage.setItem('vimsite_token', t);
+  }
+
+  function requireAuth(): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const t = getToken();
+      if (t) return resolve(t);
+      const ov = el('div', 'editor-overlay');
+      const box = el('div', 'editor-box');
+      box.style.maxWidth = '500px';
+      box.innerHTML =
+        '<div class="editor-header">github token required</div>' +
+        '<div style="padding:1rem">' +
+        '<p style="margin-bottom:1rem;color:var(--fg-dim);font-size:0.75rem">' +
+        'fine-grained PAT scoped to <strong>' +
+        OWNER +
+        '/' +
+        REPO +
+        '</strong> with <strong>contents: read/write</strong></p>' +
+        '<input type="password" class="editor-input" id="ed-token" ' +
+        'placeholder="github_pat_..." style="width:100%">' +
+        '<p style="margin-top:0.75rem;font-size:0.65rem;color:var(--border)">' +
+        '<a href="https://github.com/settings/personal-access-tokens/new" ' +
+        'target="_blank" rel="noopener">create token</a></p></div>' +
+        '<div class="editor-status">enter: save · esc: cancel</div>';
+      ov.appendChild(box);
+      document.body.appendChild(ov);
+      const inp = document.getElementById('ed-token') as HTMLInputElement;
+      inp.focus();
+      inp.addEventListener('keydown', (e: KeyboardEvent) => {
+        if (e.key === 'Enter' && inp.value.trim()) {
+          setToken(inp.value.trim());
+          document.body.removeChild(ov);
+          resolve(inp.value.trim());
+        } else if (e.key === 'Escape') {
+          document.body.removeChild(ov);
+          reject(new Error('cancelled'));
+        }
+      });
+    });
+  }
+  // ====== GitHub API ======
+
+  function gh<T>(method: string, path: string, token: string, body?: unknown): Promise<T> {
+    const opts: RequestInit = {
+      method,
+      headers: {
+        Authorization: 'token ' + token,
+        Accept: 'application/vnd.github.v3+json',
+      },
+    };
+    if (body) {
+      (opts.headers as Record<string, string>)['Content-Type'] = 'application/json';
+      opts.body = JSON.stringify(body);
+    }
+    return fetch(API + '/' + path, opts).then((r) => {
+      if (!r.ok) return r.text().then((t) => Promise.reject(new Error(r.status + ': ' + t)));
+      return r.status === 204 ? (null as T) : (r.json() as Promise<T>);
+    });
+  }
+
+  function getFile(path: string, token: string): Promise<{ content: string; sha: string }> {
+    return gh<GitHubContent>('GET', 'contents/' + path + '?ref=' + BRANCH, token).then((d) => {
+      const raw = atob(d.content.replace(/\s/g, ''));
+      const bytes = new Uint8Array(raw.length);
+      for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
+      return { content: new TextDecoder().decode(bytes), sha: d.sha };
+    });
+  }
+
+  function multiCommit(token: string, message: string, files: FileEntry[]): Promise<void> {
+    let commitSha: string;
+    return gh<GitHubRef>('GET', 'git/ref/heads/' + BRANCH, token)
+      .then((ref) => {
+        commitSha = ref.object.sha;
+        return gh<GitHubCommit>('GET', 'git/commits/' + commitSha, token);
+      })
+      .then((commit) => {
+        const tree: TreeEntry[] = files.map((f) => {
+          if (f.delete)
+            return { path: f.path, mode: '100644' as const, type: 'blob' as const, sha: null };
+          return {
+            path: f.path,
+            mode: '100644' as const,
+            type: 'blob' as const,
+            content: f.content,
+          };
+        });
+        return gh<GitHubTree>('POST', 'git/trees', token, { base_tree: commit.tree.sha, tree });
+      })
+      .then((newTree) => {
+        return gh<GitHubCommit>('POST', 'git/commits', token, {
+          message,
+          tree: newTree.sha,
+          parents: [commitSha],
+        });
+      })
+      .then((c) => {
+        return gh<null>('PATCH', 'git/refs/heads/' + BRANCH, token, { sha: c.sha }).then(() => {});
+      });
+  }
+  // ====== Post HTML ======
+
+  function generatePost(o: PostGenerateOptions): string {
+    const paras = o.content
+      .split(/\n\n+/)
+      .filter(Boolean)
+      .map((p) => {
+        return '      <p>\n        ' + esc(p.trim()).replace(/\n/g, '\n        ') + '\n      </p>';
+      })
+      .join('\n\n');
+
+    let body: string;
+    if (o.type === 'spoken') {
+      body =
+        '    <div class="spoken-transcript">\n' +
+        '      <p class="spoken-label">transcribed via spokenly · lightly edited</p>\n\n' +
+        paras +
+        '\n    </div>';
+    } else {
+      body = paras;
+    }
+
+    const tags = (o.tags || [])
+      .map((t) => '      <span class="tag">' + esc(t) + '</span>')
+      .join('\n');
+
+    const nav: string[] = [];
+    if (o.prevSlug)
+      nav.push('    <a class="prev" href="' + o.prevSlug + '.html">\u2190 ' + o.prevSlug + '</a>');
+    nav.push(
+      '    <a class="back" href="../index.html">' + (o.prevSlug ? '' : '\u2190 ') + '~/log</a>',
+    );
+    if (o.nextSlug)
+      nav.push('    <a class="next" href="' + o.nextSlug + '.html">' + o.nextSlug + ' \u2192</a>');
+
+    return (
+      '<!DOCTYPE html>\n<html lang="en">\n<head>\n' +
+      '  <meta charset="UTF-8">\n  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n' +
+      '  <title>' +
+      o.slug +
+      ' \u2014 log</title>\n' +
+      '  <link rel="stylesheet" href="../assets/css/style.css">\n</head>\n<body>\n' +
+      '  <header>\n    <nav style="font-size: 0.8rem; color: var(--fg-dim);">\n' +
+      '      <a href="../index.html">~/log</a> / ' +
+      o.slug +
+      '\n    </nav>\n  </header>\n\n' +
+      '  <main class="post-content">\n' +
+      '    <div class="post-meta">\n      <time datetime="' +
+      o.date +
+      '">' +
+      o.date +
+      '</time>\n' +
+      '      <span class="post-type ' +
+      o.type +
+      '">' +
+      o.type +
+      '</span>\n    </div>\n' +
+      '    <h1>' +
+      o.slug +
+      '</h1>\n\n' +
+      body +
+      '\n\n' +
+      '    <div class="post-tags">\n' +
+      tags +
+      '\n    </div>\n  </main>\n\n' +
+      '  <nav class="post-nav">\n' +
+      nav.join('\n') +
+      '\n  </nav>\n\n' +
+      '  <footer>\n    <p class="vim-hint">\u2190 \u2192 between posts \u00b7 backspace ~/log \u00b7 e edit</p>\n' +
+      '    <p class="footer-eof">EOF</p>\n  </footer>\n\n' +
+      '  <script src="../assets/js/main.js"></script>\n</body>\n</html>\n'
+    );
+  }
+
+  function parsePost(html: string): Post {
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    let content = '';
+    const transcript = doc.querySelector('.spoken-transcript');
+    if (transcript) {
+      content = Array.from(transcript.querySelectorAll('p:not(.spoken-label)'))
+        .map((p) => p.textContent?.trim() ?? '')
+        .join('\n\n');
+    } else {
+      const main = doc.querySelector('.post-content');
+      if (main)
+        content = Array.from(main.querySelectorAll(':scope > p'))
+          .map((p) => p.textContent?.trim() ?? '')
+          .join('\n\n');
+    }
+    const typeEl = doc.querySelector('.post-type');
+    const prevEl = doc.querySelector('.post-nav .prev');
+    const nextEl = doc.querySelector('.post-nav .next');
+    return {
+      slug: doc.querySelector('h1')?.textContent ?? '',
+      date: doc.querySelector('time')?.getAttribute('datetime') ?? '',
+      type: typeEl?.classList.contains('spoken') ? 'spoken' : 'written',
+      content,
+      tags: Array.from(doc.querySelectorAll('.tag')).map((t) => t.textContent?.trim() ?? ''),
+      prevSlug: prevEl ? (prevEl.getAttribute('href')?.replace('.html', '') ?? null) : null,
+      nextSlug: nextEl ? (nextEl.getAttribute('href')?.replace('.html', '') ?? null) : null,
+    };
+  }
+
+  function updatePostNav(html: string, prevSlug: string | null, nextSlug: string | null): string {
+    const s = html.indexOf('<nav class="post-nav">');
+    const e = html.indexOf('</nav>', s) + 6;
+    if (s === -1) return html;
+    const nav: string[] = [];
+    if (prevSlug)
+      nav.push('    <a class="prev" href="' + prevSlug + '.html">\u2190 ' + prevSlug + '</a>');
+    nav.push(
+      '    <a class="back" href="../index.html">' + (prevSlug ? '' : '\u2190 ') + '~/log</a>',
+    );
+    if (nextSlug)
+      nav.push('    <a class="next" href="' + nextSlug + '.html">' + nextSlug + ' \u2192</a>');
+    return (
+      html.slice(0, s) +
+      '  <nav class="post-nav">\n' +
+      nav.join('\n') +
+      '\n  </nav>' +
+      html.slice(e)
+    );
+  }
+  // ====== Index manipulation ======
+
+  function addToIndex(
+    html: string,
+    date: string,
+    type: PostType,
+    slug: string,
+    desc: string,
+  ): string {
+    const day = date.split('-')[2];
+    const ts = type === 'spoken' ? 'spkn' : 'writ';
+    const month = MONTHS[+date.split('-')[1]];
+    const year = date.split('-')[0];
+
+    const row =
+      '          <!-- post-row -->\n' +
+      '          <tr class="' +
+      type +
+      '">\n' +
+      '            <td class="ls-date" data-date="' +
+      date +
+      '">' +
+      day +
+      '</td>\n' +
+      '            <td class="ls-type ' +
+      type +
+      '">' +
+      ts +
+      '</td>\n' +
+      '            <td><a href="posts/' +
+      slug +
+      '.html">' +
+      slug +
+      '</a> ' +
+      '<span class="ls-desc">\u2014 ' +
+      esc(desc) +
+      '</span></td>\n' +
+      '          </tr>\n          <!-- /post-row -->';
+
+    const hasYear = html.indexOf('ls-group-year"><td colspan="3">' + year + '<') > -1;
+    const hasMonth = html.indexOf('ls-group-month"><td colspan="3">' + month + '<') > -1;
+
+    if (hasMonth) {
+      const tag = 'ls-group-month"><td colspan="3">' + month + '</td></tr>';
+      const pos = html.indexOf(tag) + tag.length;
+      html = html.slice(0, pos) + '\n' + row + html.slice(pos);
+    } else if (hasYear) {
+      const tag = 'ls-group-year"><td colspan="3">' + year + '</td></tr>';
+      const pos = html.indexOf(tag) + tag.length;
+      html =
+        html.slice(0, pos) +
+        '\n          <tr class="ls-group-month"><td colspan="3">' +
+        month +
+        '</td></tr>\n' +
+        row +
+        html.slice(pos);
+    } else {
+      const pos = html.indexOf('<tbody>') + 7;
+      html =
+        html.slice(0, pos) +
+        '\n          <tr class="ls-group-year"><td colspan="3">' +
+        year +
+        '</td></tr>\n          <tr class="ls-group-month"><td colspan="3">' +
+        month +
+        '</td></tr>\n' +
+        row +
+        html.slice(pos);
+    }
+    return updateCount(html);
+  }
+
+  function removeFromIndex(html: string, slug: string): string {
+    const marker = 'posts/' + slug + '.html';
+    const pos = html.indexOf(marker);
+    if (pos === -1) return html;
+    let s = html.lastIndexOf('<!-- post-row -->', pos);
+    const e = html.indexOf('<!-- /post-row -->', pos) + 18;
+    while (s > 0 && html[s - 1] === ' ') s--;
+    if (s > 0 && html[s - 1] === '\n') s--;
+    return updateCount(html.slice(0, s) + html.slice(e));
+  }
+
+  function updateCount(html: string): string {
+    const m = html.match(/<!-- post-row -->/g);
+    const n = m ? m.length : 0;
+    return html.replace(
+      /<p class="ls-count">[^<]*<\/p>/,
+      '<p class="ls-count">' + (n === 1 ? '1 entry' : n + ' entries') + '</p>',
+    );
+  }
+
+  function getNewestSlug(html: string): string | null {
+    const s = html.indexOf('<!-- post-row -->');
+    if (s === -1) return null;
+    const chunk = html.slice(s, s + 500);
+    const m = chunk.match(/posts\/([^.]+)\.html/);
+    return m ? m[1] : null;
+  }
+
+  function getDescFromIndex(html: string, slug: string): string {
+    const re = new RegExp(
+      'posts/' + slug + '\\.html">[^<]*</a>\\s*<span class="ls-desc">. ([^<]*)',
+    );
+    const m = html.match(re);
+    return m ? m[1] : '';
+  }
+  // ====== Editor UI ======
+
+  function showEditor(opts: EditorOptions): void {
+    let typeVal: PostType = opts.type || 'spoken';
+    const ov = el('div', 'editor-overlay');
+    const box = el('div', 'editor-box');
+    box.innerHTML =
+      '<div class="editor-header">' +
+      '<span class="editor-path">~/log/' +
+      (opts.mode === 'new' ? 'new' : opts.slug) +
+      '</span>' +
+      '<span class="editor-type ' +
+      typeVal +
+      '" id="ed-type">' +
+      typeVal +
+      '</span></div>' +
+      '<div class="editor-fields">' +
+      (opts.mode === 'new'
+        ? '<input type="text" class="editor-input" id="ed-slug" placeholder="post-slug" value="">'
+        : '') +
+      '<textarea class="editor-textarea" id="ed-content" placeholder="start typing...">' +
+      (opts.content || '') +
+      '</textarea>' +
+      '<input type="text" class="editor-input" id="ed-desc" placeholder="short description" value="' +
+      (opts.desc || '').replace(/"/g, '&quot;') +
+      '">' +
+      '<input type="text" class="editor-input" id="ed-tags" placeholder="tags (comma separated)" value="' +
+      (opts.tags || []).join(', ') +
+      '"></div>' +
+      '<div class="editor-status" id="ed-status">esc \u2192 command mode \u00b7 :w save \u00b7 :q quit \u00b7 :t toggle type</div>';
+
+    ov.setAttribute('tabindex', '-1');
+    ov.appendChild(box);
+    document.body.appendChild(ov);
+
+    const ta = document.getElementById('ed-content') as HTMLTextAreaElement;
+    const status = document.getElementById('ed-status') as HTMLElement;
+    const typeEl = document.getElementById('ed-type') as HTMLElement;
+    let cmdMode = false;
+    let cmdBuf = '';
+    ta.focus();
+
+    // auto-fill description from content
+    ta.addEventListener('input', () => {
+      const desc = document.getElementById('ed-desc') as HTMLInputElement;
+      if (!desc.dataset.manual) {
+        const words = ta.value.trim().split(/\s+/).slice(0, 8).join(' ');
+        desc.value = words.length > 50 ? words.slice(0, 50) + '...' : words;
+      }
+    });
+    (document.getElementById('ed-desc') as HTMLInputElement).addEventListener('input', function () {
+      this.dataset.manual = '1';
+    });
+
+    // clickable type toggle
+    typeEl.addEventListener('click', () => {
+      typeVal = typeVal === 'spoken' ? 'written' : 'spoken';
+      typeEl.textContent = typeVal;
+      typeEl.className = 'editor-type ' + typeVal;
+    });
+
+    function cleanup(): void {
+      if (ov.parentNode) document.body.removeChild(ov);
+    }
+
+    function execCmd(cmd: string): void {
+      cmd = cmd.trim().toLowerCase();
+      if (cmd === 'w' || cmd === 'wq') {
+        const slug =
+          opts.mode === 'new'
+            ? slugify(
+                (document.getElementById('ed-slug') as HTMLInputElement).value.trim() ||
+                  ta.value.slice(0, 40),
+              )
+            : (opts.slug as string);
+        if (!slug) {
+          status.textContent = 'error: need a slug';
+          return;
+        }
+        if (!ta.value.trim()) {
+          status.textContent = 'error: no content';
+          return;
+        }
+        status.textContent = 'saving...';
+        const result: EditorSaveResult = {
+          slug,
+          type: typeVal,
+          content: ta.value,
+          desc: (document.getElementById('ed-desc') as HTMLInputElement).value.trim() || slug,
+          tags: (document.getElementById('ed-tags') as HTMLInputElement).value
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean),
+        };
+        opts.onSave(result).then(
+          () => {
+            if (cmd === 'wq') {
+              cleanup();
+            } else {
+              status.textContent = 'committed. reload in ~15s to see changes.';
+            }
+          },
+          (err: Error) => {
+            status.textContent = 'error: ' + err.message;
+            if (err.message.indexOf('401') > -1 || err.message.indexOf('403') > -1) {
+              localStorage.removeItem('vimsite_token');
+              status.textContent = 'bad token \u2014 cleared. reload and try again.';
+            }
+          },
+        );
+      } else if (cmd === 'q' || cmd === 'q!') {
+        cleanup();
+      } else if (cmd === 't') {
+        typeVal = typeVal === 'spoken' ? 'written' : 'spoken';
+        typeEl.textContent = typeVal;
+        typeEl.className = 'editor-type ' + typeVal;
+        status.textContent = 'type: ' + typeVal;
+        cmdMode = false;
+        ta.focus();
+      } else {
+        status.textContent = 'unknown: :' + cmd;
+      }
+    }
+
+    ov.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (cmdMode) {
+        e.stopPropagation();
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          execCmd(cmdBuf);
+          cmdMode = false;
+          cmdBuf = '';
+        } else if (e.key === 'Escape') {
+          cmdMode = false;
+          cmdBuf = '';
+          status.textContent = 'esc \u2192 command mode';
+          ta.focus();
+        } else if (e.key === 'Backspace') {
+          cmdBuf = cmdBuf.slice(0, -1);
+          status.textContent = ':' + cmdBuf;
+          if (!cmdBuf) {
+            cmdMode = false;
+            status.textContent = 'esc \u2192 command mode';
+            ta.focus();
+          }
+        } else if (e.key.length === 1) {
+          cmdBuf += e.key;
+          status.textContent = ':' + cmdBuf;
+        }
+        return;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        cmdMode = true;
+        cmdBuf = '';
+        status.textContent = ':';
+        ta.blur();
+        ov.focus();
+      }
+    });
+  }
+
+  function showDeleteConfirm(slug: string, onConfirm: () => Promise<void>): void {
+    const ov = el('div', 'editor-overlay');
+    const box = el('div', 'editor-box');
+    box.style.maxWidth = '450px';
+    let stage = 0;
+    const msgs = [
+      'press d to confirm \u00b7 any other key to cancel',
+      'press d again \u00b7 any other key to cancel',
+      'FINAL \u2014 press d to delete permanently',
+    ];
+
+    function render(): void {
+      box.innerHTML =
+        '<div class="editor-header delete-header">!! delete ' +
+        slug +
+        ' !!</div>' +
+        '<div style="padding:1.5rem;text-align:center"><p style="font-size:0.8rem">' +
+        msgs[stage] +
+        '</p>' +
+        '<div class="delete-progress">' +
+        '<span class="delete-dot ' +
+        (stage >= 0 ? 'active' : '') +
+        '">d</span>' +
+        '<span class="delete-dot ' +
+        (stage >= 1 ? 'active' : '') +
+        '">d</span>' +
+        '<span class="delete-dot ' +
+        (stage >= 2 ? 'active' : '') +
+        '">d</span>' +
+        '</div></div>';
+    }
+
+    render();
+    ov.appendChild(box);
+    document.body.appendChild(ov);
+
+    function handler(e: KeyboardEvent): void {
+      e.preventDefault();
+      e.stopPropagation();
+      if (e.key === 'd') {
+        stage++;
+        if (stage >= 3) {
+          document.removeEventListener('keydown', handler, true);
+          box.innerHTML =
+            '<div class="editor-header delete-header">!! deleting !!</div>' +
+            '<div style="padding:1.5rem;text-align:center"><p style="font-size:0.8rem">removing...</p></div>';
+          onConfirm().then(
+            () => {
+              const p = box.querySelector('p');
+              if (p) p.textContent = 'done. reload to see changes.';
+              setTimeout(() => {
+                if (ov.parentNode) document.body.removeChild(ov);
+              }, 2000);
+            },
+            (err: Error) => {
+              const p = box.querySelector('p');
+              if (p) p.textContent = 'error: ' + err.message;
+            },
+          );
+        } else {
+          render();
+        }
+      } else {
+        document.removeEventListener('keydown', handler, true);
+        document.body.removeChild(ov);
+      }
+    }
+
+    document.addEventListener('keydown', handler, true);
+  }
+  // ====== Workflows ======
+
+  function newEntry(token: string): void {
+    showEditor({
+      mode: 'new',
+      type: 'spoken',
+      onSave: (r) => {
+        return getFile('index.html', token).then((idx) => {
+          const newest = getNewestSlug(idx.content);
+          const date = today();
+          const postHtml = generatePost({
+            slug: r.slug,
+            date,
+            type: r.type,
+            content: r.content,
+            tags: r.tags,
+            prevSlug: null,
+            nextSlug: newest,
+          });
+          const newIndex = addToIndex(idx.content, date, r.type, r.slug, r.desc);
+          const files: FileEntry[] = [
+            { path: 'posts/' + r.slug + '.html', content: postHtml },
+            { path: 'index.html', content: newIndex },
+          ];
+          if (newest) {
+            return getFile('posts/' + newest + '.html', token).then((f) => {
+              const parsed = parsePost(f.content);
+              files.push({
+                path: 'posts/' + newest + '.html',
+                content: updatePostNav(f.content, r.slug, parsed.nextSlug),
+              });
+              return multiCommit(token, 'feat: add post ' + r.slug, files);
+            });
+          }
+          return multiCommit(token, 'feat: add post ' + r.slug, files);
+        });
+      },
+    });
+  }
+
+  function editEntry(slug: string, token: string): void {
+    getFile('posts/' + slug + '.html', token).then((file) => {
+      const post = parsePost(file.content);
+      getFile('index.html', token).then((idx) => {
+        const desc = getDescFromIndex(idx.content, slug);
+        showEditor({
+          mode: 'edit',
+          slug,
+          type: post.type,
+          content: post.content,
+          tags: post.tags,
+          desc,
+          onSave: (r) => {
+            const postHtml = generatePost({
+              slug,
+              date: post.date,
+              type: r.type,
+              content: r.content,
+              tags: r.tags,
+              prevSlug: post.prevSlug,
+              nextSlug: post.nextSlug,
+            });
+            let newIndex = removeFromIndex(idx.content, slug);
+            newIndex = addToIndex(newIndex, post.date, r.type, slug, r.desc);
+            return multiCommit(token, 'edit: update ' + slug, [
+              { path: 'posts/' + slug + '.html', content: postHtml },
+              { path: 'index.html', content: newIndex },
+            ]);
+          },
+        });
+      });
+    });
+  }
+
+  function deleteEntry(slug: string, token: string): void {
+    showDeleteConfirm(slug, () => {
+      return getFile('posts/' + slug + '.html', token).then((file) => {
+        const post = parsePost(file.content);
+        return getFile('index.html', token).then((idx) => {
+          const newIndex = removeFromIndex(idx.content, slug);
+          const files: FileEntry[] = [
+            { path: 'posts/' + slug + '.html', delete: true },
+            { path: 'index.html', content: newIndex },
+          ];
+          const adj: Promise<void>[] = [];
+          if (post.prevSlug) {
+            adj.push(
+              getFile('posts/' + post.prevSlug + '.html', token).then((f) => {
+                files.push({
+                  path: 'posts/' + post.prevSlug + '.html',
+                  content: updatePostNav(f.content, parsePost(f.content).prevSlug, post.nextSlug),
+                });
+              }),
+            );
+          }
+          if (post.nextSlug) {
+            adj.push(
+              getFile('posts/' + post.nextSlug + '.html', token).then((f) => {
+                files.push({
+                  path: 'posts/' + post.nextSlug + '.html',
+                  content: updatePostNav(f.content, post.prevSlug, parsePost(f.content).nextSlug),
+                });
+              }),
+            );
+          }
+          return Promise.all(adj).then(() => {
+            return multiCommit(token, 'delete: remove ' + slug, files);
+          });
+        });
+      });
+    });
+  }
+  // ====== Public API ======
+
+  window.__editor = {
+    newEntry: () => {
+      requireAuth()
+        .then(newEntry)
+        .catch(() => {});
+    },
+    editEntry: (slug: string) => {
+      requireAuth()
+        .then((t) => editEntry(slug, t))
+        .catch(() => {});
+    },
+    deleteEntry: (slug: string) => {
+      requireAuth()
+        .then((t) => deleteEntry(slug, t))
+        .catch(() => {});
+    },
+    clearToken: () => {
+      localStorage.removeItem('vimsite_token');
+    },
+  };
+})();

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,13 @@
+/* Global type declarations for vimsite */
+
+interface EditorAPI {
+  newEntry: () => void;
+  editEntry: (slug: string) => void;
+  deleteEntry: (slug: string) => void;
+  clearToken: () => void;
+}
+
+interface Window {
+  __editor?: EditorAPI;
+  __vizModules: Record<string, (el: HTMLElement) => void>;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,160 @@
+/* log — main.ts — minimal */
+
+(function () {
+  'use strict';
+
+  // --- J2000 day number (days since 2000-01-01 12:00 TT) ---
+  function j2000(y: number, m: number, d: number): number {
+    const a = Math.floor((14 - m) / 12);
+    const yy = y + 4800 - a;
+    const mm = m + 12 * a - 3;
+    const jdn =
+      d +
+      Math.floor((153 * mm + 2) / 5) +
+      365 * yy +
+      Math.floor(yy / 4) -
+      Math.floor(yy / 100) +
+      Math.floor(yy / 400) -
+      32045;
+    return jdn - 2451545;
+  }
+
+  function injectJ2000(): void {
+    document.querySelectorAll<HTMLElement>('.ls-date[data-date]').forEach((el) => {
+      const p = (el.dataset.date ?? '').split('-');
+      const span = document.createElement('span');
+      span.className = 'j2000';
+      span.textContent = 'J' + j2000(+p[0], +p[1], +p[2]);
+      el.appendChild(span);
+    });
+    document.querySelectorAll<HTMLElement>('.post-meta time[datetime]').forEach((el) => {
+      const p = (el.getAttribute('datetime') ?? '').split('-');
+      const span = document.createElement('span');
+      span.className = 'j2000';
+      span.textContent = 'J' + j2000(+p[0], +p[1], +p[2]);
+      el.parentNode?.insertBefore(span, el.nextSibling);
+    });
+  }
+
+  injectJ2000();
+
+  // --- lazy-load editor.js ---
+  function loadEditor(fn: () => void): void {
+    if (window.__editor) {
+      fn();
+      return;
+    }
+    const s = document.createElement('script');
+    const isPost = !!document.querySelector('.post-content');
+    s.src = (isPost ? '../' : '') + 'assets/js/editor.js';
+    s.onload = fn;
+    document.head.appendChild(s);
+  }
+
+  // --- vim j/k/↑/↓/Enter nav on ls table rows (skips group headers) ---
+  const rows = document.querySelectorAll<HTMLTableRowElement>(
+    '.ls-table tbody tr:not(.ls-group-year):not(.ls-group-month)',
+  );
+  let cur = -1;
+
+  function select(i: number): void {
+    rows.forEach((r) => r.classList.remove('selected'));
+    if (i >= 0 && i < rows.length) {
+      rows[i].classList.add('selected');
+      rows[i].scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }
+
+  function getSelectedSlug(): string | null {
+    if (cur < 0 || !rows[cur]) return null;
+    const link = rows[cur].querySelector('a');
+    if (!link) return null;
+    const m = link.getAttribute('href')?.match(/posts\/([^.]+)\.html/);
+    return m ? m[1] : null;
+  }
+
+  function getCurrentSlug(): string | null {
+    const m = location.pathname.match(/posts\/([^.]+)\.html/);
+    return m ? m[1] : null;
+  }
+
+  document.addEventListener('keydown', (e: KeyboardEvent) => {
+    const target = e.target as HTMLElement;
+    if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') return;
+    if (document.querySelector('.editor-overlay')) return;
+
+    // j / ArrowDown — move down
+    if (e.key === 'j' || e.key === 'ArrowDown') {
+      if (!rows.length) return;
+      e.preventDefault();
+      cur = Math.min(cur + 1, rows.length - 1);
+      select(cur);
+    }
+    // k / ArrowUp — move up
+    else if (e.key === 'k' || e.key === 'ArrowUp') {
+      if (!rows.length) return;
+      e.preventDefault();
+      cur = Math.max(cur - 1, 0);
+      select(cur);
+    }
+    // Enter — open selected entry
+    else if (e.key === 'Enter' && cur >= 0) {
+      const link = rows[cur].querySelector('a');
+      if (link) (link as HTMLAnchorElement).click();
+    }
+    // ArrowLeft — prev (newer) post
+    else if (e.key === 'ArrowLeft') {
+      const prev = document.querySelector<HTMLAnchorElement>('.post-nav .prev');
+      if (prev) {
+        e.preventDefault();
+        prev.click();
+      }
+    }
+    // ArrowRight — next (older) post
+    else if (e.key === 'ArrowRight') {
+      const next = document.querySelector<HTMLAnchorElement>('.post-nav .next');
+      if (next) {
+        e.preventDefault();
+        next.click();
+      }
+    }
+    // Backspace — back to ~/log
+    else if (e.key === 'Backspace') {
+      const back =
+        document.querySelector<HTMLAnchorElement>('.post-nav .back') ??
+        document.querySelector<HTMLAnchorElement>('nav a[href*="index"]');
+      if (back) {
+        e.preventDefault();
+        back.click();
+      }
+    }
+    // n — new entry (index page only)
+    else if (e.key === 'n' && !document.querySelector('.post-content')) {
+      e.preventDefault();
+      loadEditor(() => window.__editor?.newEntry());
+    }
+    // e — edit entry (post page or selected index row)
+    else if (e.key === 'e') {
+      const slug = document.querySelector('.post-content') ? getCurrentSlug() : getSelectedSlug();
+      if (slug) {
+        e.preventDefault();
+        loadEditor(() => window.__editor?.editEntry(slug));
+      }
+    }
+    // d — delete entry (index page, with selection)
+    else if (e.key === 'd' && !document.querySelector('.post-content')) {
+      const slug = getSelectedSlug();
+      if (slug) {
+        e.preventDefault();
+        loadEditor(() => window.__editor?.deleteEntry(slug));
+      }
+    }
+  });
+
+  // --- viz module registry ---
+  window.__vizModules = window.__vizModules || {};
+  document.querySelectorAll<HTMLElement>('.viz-embed[data-viz]').forEach((el) => {
+    const mod = window.__vizModules[el.dataset.viz ?? ''];
+    if (mod) mod(el);
+  });
+})();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2020",
+    "module": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "outDir": "assets/js",
+    "rootDir": "src",
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- **TypeScript strict mode**: `src/main.ts` and `src/editor.ts` are now the source of truth, compiled to `assets/js/` via esbuild
- **Linting pipeline**: ESLint (@typescript-eslint/strict), Stylelint (standard config), Prettier — all clean
- **Pre-commit hooks**: husky + lint-staged auto-fix on staged files
- **CI update**: build → lint → type-check → format-check runs before GitHub Pages deploy

## What changed
| File | Change |
|------|--------|
| `src/main.ts` | New — typed conversion of `assets/js/main.js` |
| `src/editor.ts` | New — typed conversion of `assets/js/editor.js` (495→810 lines with types) |
| `src/globals.d.ts` | New — shared Window type augmentation |
| `package.json` | New — devDependencies, build/lint scripts, lint-staged config |
| `tsconfig.json` | New — strict mode, ES2020 target, noEmit for type-check only |
| `eslint.config.mjs` | New — flat config with @typescript-eslint/strict |
| `.stylelintrc.json` | New — stylelint-config-standard |
| `.prettierrc` | New — single quotes, trailing commas, 100 width |
| `.husky/pre-commit` | New — runs lint-staged |
| `assets/js/*.js` | Updated — compiled output from TypeScript source |
| `assets/css/style.css` | Auto-fixed — color notation, hex length, media queries |
| `*.html` | Prettier-formatted only — no content changes |
| `.github/workflows/pages.yml` | Added Node.js setup, build, lint, format-check steps |

## What's NOT changed
- Zero blog post content changes (all HTML changes are Prettier formatting only)
- No new runtime dependencies — all devDependencies
- No changes to site behavior or appearance

## Test plan
- [ ] `npm run build` compiles clean
- [ ] `npm run lint` passes (ESLint + Stylelint + tsc --noEmit)
- [ ] `npm run format:check` passes
- [ ] Open `index.html` in browser — verify site looks identical
- [ ] CI workflow passes on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)