### PR TITLE
perf: eliminate render-blocking font waterfall

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -3,7 +3,8 @@
    terminal ls/tree aesthetic · fast-loading
    ============================================ */
 
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,500;0,600;1,400&display=swap');
+/* Google Fonts loaded via <link> in HTML <head> for parallel fetch.
+   Do NOT re-add @import here — it creates a render-blocking chain. */
 
 :root {
   --bg: #0a0e0a;

--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>log</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,500;0,600;1,400&display=swap"
+    />
     <link rel="stylesheet" href="assets/css/style.css" />
   </head>
   <body>
@@ -144,6 +150,6 @@
       <p class="footer-eof">EOF</p>
     </footer>
 
-    <script src="assets/js/main.js"></script>
+    <script src="assets/js/main.js" defer></script>
   </body>
 </html>

--- a/posts/entry-number-one.html
+++ b/posts/entry-number-one.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>entry-number-one — log</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,500;0,600;1,400&display=swap"
+    />
     <link rel="stylesheet" href="../assets/css/style.css" />
   </head>
   <body>
@@ -43,6 +49,6 @@
       <p class="footer-eof">EOF</p>
     </footer>
 
-    <script src="../assets/js/main.js"></script>
+    <script src="../assets/js/main.js" defer></script>
   </body>
 </html>

--- a/posts/hello-world.html
+++ b/posts/hello-world.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>hello-world — log</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,500;0,600;1,400&display=swap"
+    />
     <link rel="stylesheet" href="../assets/css/style.css" />
   </head>
   <body>
@@ -74,6 +80,6 @@
       <p class="footer-eof">EOF</p>
     </footer>
 
-    <script src="../assets/js/main.js"></script>
+    <script src="../assets/js/main.js" defer></script>
   </body>
 </html>

--- a/posts/test-drone-nav.html
+++ b/posts/test-drone-nav.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>test-drone-nav — log</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,500;0,600;1,400&display=swap"
+    />
     <link rel="stylesheet" href="../assets/css/style.css" />
   </head>
   <body>
@@ -59,6 +65,6 @@
       <p class="footer-eof">EOF</p>
     </footer>
 
-    <script src="../assets/js/main.js"></script>
+    <script src="../assets/js/main.js" defer></script>
   </body>
 </html>

--- a/posts/test-mtg-bot.html
+++ b/posts/test-mtg-bot.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>test-mtg-bot — log</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,500;0,600;1,400&display=swap"
+    />
     <link rel="stylesheet" href="../assets/css/style.css" />
   </head>
   <body>
@@ -54,6 +60,6 @@
       <p class="footer-eof">EOF</p>
     </footer>
 
-    <script src="../assets/js/main.js"></script>
+    <script src="../assets/js/main.js" defer></script>
   </body>
 </html>

--- a/posts/test-pension-data.html
+++ b/posts/test-pension-data.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>test-pension-data — log</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,500;0,600;1,400&display=swap"
+    />
     <link rel="stylesheet" href="../assets/css/style.css" />
   </head>
   <body>
@@ -68,6 +74,6 @@
       <p class="footer-eof">EOF</p>
     </footer>
 
-    <script src="../assets/js/main.js"></script>
+    <script src="../assets/js/main.js" defer></script>
   </body>
 </html>

--- a/posts/test-post-number-two.html
+++ b/posts/test-post-number-two.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>test-post-number-two — log</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,500;0,600;1,400&display=swap"
+    />
     <link rel="stylesheet" href="../assets/css/style.css" />
   </head>
   <body>
@@ -43,6 +49,6 @@
       <p class="footer-eof">EOF</p>
     </footer>
 
-    <script src="../assets/js/main.js"></script>
+    <script src="../assets/js/main.js" defer></script>
   </body>
 </html>

--- a/posts/test-wasm-viz.html
+++ b/posts/test-wasm-viz.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>test-wasm-viz — log</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,500;0,600;1,400&display=swap"
+    />
     <link rel="stylesheet" href="../assets/css/style.css" />
   </head>
   <body>
@@ -69,6 +75,6 @@
       <p class="footer-eof">EOF</p>
     </footer>
 
-    <script src="../assets/js/main.js"></script>
+    <script src="../assets/js/main.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Moved Google Fonts from CSS `@import` to `<link rel="stylesheet">` in HTML `<head>` across all pages
- Added `<link rel="preconnect">` hints for `fonts.googleapis.com` and `fonts.gstatic.com` to eliminate DNS/TLS round trips
- Added `defer` attribute to all `<script>` tags for non-blocking JS loading

## Why
The CSS `@import` created a render-blocking waterfall: HTML → CSS → Google Fonts CSS → .woff2 files (3 sequential network requests). Moving to `<link>` in HTML enables parallel fetching, cutting at least one full round trip from page load.

## Files changed
- `assets/css/style.css` — removed `@import`, added comment
- `index.html` — added preconnect + font stylesheet link, defer on script
- All 7 `posts/*.html` — same preconnect/link/defer changes

## Test plan
- [ ] Check Cloudflare preview deploy renders correctly with fonts loaded
- [ ] Verify no FOUT (flash of unstyled text) on page load
- [ ] Navigate between posts — should feel snappier

🤖 Generated with [Claude Code](https://claude.com/claude-code)