### PR TITLE
fix: add api.github.com to CSP connect-src

### DIFF
--- a/_headers
+++ b/_headers
@@ -4,4 +4,4 @@
   X-XSS-Protection: 0
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(), camera=(), microphone=(), payment=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src 'self' https://ipapi.co; img-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src 'self' https://ipapi.co https://api.github.com; img-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'


### PR DESCRIPTION
## Summary
- Editor `fetch()` calls to `api.github.com` were being blocked by the `connect-src` CSP directive, which only allowed `'self'` and `https://ipapi.co`
- Adds `https://api.github.com` so the in-browser editor can create/edit/delete posts

## Test plan
- [ ] On the preview URL, select a post and press `d` — confirm delete flow completes without CSP error
- [ ] Press `e` on a post — confirm edit save works
- [ ] Press `n` — confirm new post creation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)