### PR TITLE
fix: run prettier on unformatted HTML files

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,55 @@
+# Standard .claudeignore for all repos
+# Prevents Claude from wasting tokens on irrelevant files
+
+# Data files
+data/
+*.csv
+*.csv.gz
+*.parquet
+*.jsonl
+*.json.gz
+
+# Model weights and checkpoints
+checkpoints/
+*.pt
+*.pth
+*.onnx
+*.safetensors
+*.bin
+
+# Logs and experiment tracking
+logs/
+wandb/
+mlruns/
+*.log
+
+# Build artifacts
+dist/
+build/
+*.egg-info/
+__pycache__/
+node_modules/
+.next/
+target/
+
+# Large binary assets
+*.mp4
+*.mov
+*.zip
+*.tar.gz
+*.blend1
+
+# IDE and OS
+.idea/
+.vscode/
+.DS_Store
+
+# Virtual environments
+.venv/
+venv/
+.tox/
+
+# Coverage reports
+htmlcov/
+.coverage
+coverage.xml

--- a/index.html
+++ b/index.html
@@ -55,15 +55,24 @@
             </tr>
           </thead>
           <tbody>
-          <tr class="ls-group-year"><td colspan="3">2026</td></tr>
-          <tr class="ls-group-month"><td colspan="3">march</td></tr>
-          <!-- post-row -->
-          <tr class="written">
-            <td class="ls-date" data-date="2026-03-05">05</td>
-            <td class="ls-type written">writ</td>
-            <td><a href="posts/illinois-kolache-five-centuries-of-fi.html">illinois-kolache-five-centuries-of-fi</a> <span class="ls-desc">— ILLINOIS KOLACHE // FIVE CENTURIES OF FILLING Want...</span></td>
-          </tr>
-          <!-- /post-row -->
+            <tr class="ls-group-year">
+              <td colspan="3">2026</td>
+            </tr>
+            <tr class="ls-group-month">
+              <td colspan="3">march</td>
+            </tr>
+            <!-- post-row -->
+            <tr class="written">
+              <td class="ls-date" data-date="2026-03-05">05</td>
+              <td class="ls-type written">writ</td>
+              <td>
+                <a href="posts/illinois-kolache-five-centuries-of-fi.html"
+                  >illinois-kolache-five-centuries-of-fi</a
+                >
+                <span class="ls-desc">— ILLINOIS KOLACHE // FIVE CENTURIES OF FILLING Want...</span>
+              </td>
+            </tr>
+            <!-- /post-row -->
             <tr class="ls-group-year">
               <td colspan="3">2026</td>
             </tr>

--- a/posts/lorem-ipsum-spoken-five.html
+++ b/posts/lorem-ipsum-spoken-five.html
@@ -34,11 +34,13 @@
       <div class="post-tags"></div>
     </main>
 
-      <nav class="post-nav">
-    <a class="prev" href="illinois-kolache-five-centuries-of-fi.html">← illinois-kolache-five-centuries-of-fi</a>
-    <a class="back" href="../index.html">~/log</a>
-    <a class="next" href="lorem-ipsum-written-four.html">lorem-ipsum-written-four →</a>
-  </nav>
+    <nav class="post-nav">
+      <a class="prev" href="illinois-kolache-five-centuries-of-fi.html"
+        >← illinois-kolache-five-centuries-of-fi</a
+      >
+      <a class="back" href="../index.html">~/log</a>
+      <a class="next" href="lorem-ipsum-written-four.html">lorem-ipsum-written-four →</a>
+    </nav>
 
     <footer>
       <p class="vim-hint">← → between posts · backspace ~/log · e edit</p>

--- a/posts/lorem-ipsum-spoken-three.html
+++ b/posts/lorem-ipsum-spoken-three.html
@@ -34,11 +34,11 @@
       <div class="post-tags"></div>
     </main>
 
-      <nav class="post-nav">
-    <a class="prev" href="lorem-ipsum-written-four.html">← lorem-ipsum-written-four</a>
-    <a class="back" href="../index.html">~/log</a>
-    <a class="next" href="lorem-ipsum-written-two.html">lorem-ipsum-written-two →</a>
-  </nav>
+    <nav class="post-nav">
+      <a class="prev" href="lorem-ipsum-written-four.html">← lorem-ipsum-written-four</a>
+      <a class="back" href="../index.html">~/log</a>
+      <a class="next" href="lorem-ipsum-written-two.html">lorem-ipsum-written-two →</a>
+    </nav>
 
     <footer>
       <p class="vim-hint">← → between posts · backspace ~/log · e edit</p>

--- a/posts/lorem-ipsum-written-four.html
+++ b/posts/lorem-ipsum-written-four.html
@@ -30,11 +30,11 @@
       <div class="post-tags"></div>
     </main>
 
-      <nav class="post-nav">
-    <a class="prev" href="lorem-ipsum-spoken-five.html">← lorem-ipsum-spoken-five</a>
-    <a class="back" href="../index.html">~/log</a>
-    <a class="next" href="lorem-ipsum-spoken-three.html">lorem-ipsum-spoken-three →</a>
-  </nav>
+    <nav class="post-nav">
+      <a class="prev" href="lorem-ipsum-spoken-five.html">← lorem-ipsum-spoken-five</a>
+      <a class="back" href="../index.html">~/log</a>
+      <a class="next" href="lorem-ipsum-spoken-three.html">lorem-ipsum-spoken-three →</a>
+    </nav>
 
     <footer>
       <p class="vim-hint">← → between posts · backspace ~/log · e edit</p>


### PR DESCRIPTION
## Summary
- 4 HTML files (`index.html` + 3 posts) had formatting drift causing `format:check` to fail
- Every open PR is currently blocked by this CI failure
- Once merged, all open PRs should pass the format check (after rebasing)

## Test plan
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)