### PR TITLE
feat: auto-format content HTML on push to main

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,0 +1,37 @@
+name: Auto-format content
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "index.html"
+      - "posts/**/*.html"
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run Prettier on content files
+        run: npx prettier --write 'index.html' 'posts/**/*.html'
+
+      - name: Commit if changed
+        run: |
+          git diff --quiet && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add index.html 'posts/**/*.html'
+          git commit -m "style: auto-format content HTML
+
+          Triggered by content push to main.
+
+          Co-Authored-By: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          git push

--- a/index.html
+++ b/index.html
@@ -55,15 +55,24 @@
             </tr>
           </thead>
           <tbody>
-          <tr class="ls-group-year"><td colspan="3">2026</td></tr>
-          <tr class="ls-group-month"><td colspan="3">march</td></tr>
-          <!-- post-row -->
-          <tr class="written">
-            <td class="ls-date" data-date="2026-03-05">05</td>
-            <td class="ls-type written">writ</td>
-            <td><a href="posts/illinois-kolache-five-centuries-of-fi.html">illinois-kolache-five-centuries-of-fi</a> <span class="ls-desc">— ILLINOIS KOLACHE // FIVE CENTURIES OF FILLING Want...</span></td>
-          </tr>
-          <!-- /post-row -->
+            <tr class="ls-group-year">
+              <td colspan="3">2026</td>
+            </tr>
+            <tr class="ls-group-month">
+              <td colspan="3">march</td>
+            </tr>
+            <!-- post-row -->
+            <tr class="written">
+              <td class="ls-date" data-date="2026-03-05">05</td>
+              <td class="ls-type written">writ</td>
+              <td>
+                <a href="posts/illinois-kolache-five-centuries-of-fi.html"
+                  >illinois-kolache-five-centuries-of-fi</a
+                >
+                <span class="ls-desc">— ILLINOIS KOLACHE // FIVE CENTURIES OF FILLING Want...</span>
+              </td>
+            </tr>
+            <!-- /post-row -->
             <tr class="ls-group-year">
               <td colspan="3">2026</td>
             </tr>

--- a/posts/lorem-ipsum-spoken-five.html
+++ b/posts/lorem-ipsum-spoken-five.html
@@ -34,11 +34,13 @@
       <div class="post-tags"></div>
     </main>
 
-      <nav class="post-nav">
-    <a class="prev" href="illinois-kolache-five-centuries-of-fi.html">← illinois-kolache-five-centuries-of-fi</a>
-    <a class="back" href="../index.html">~/log</a>
-    <a class="next" href="lorem-ipsum-written-four.html">lorem-ipsum-written-four →</a>
-  </nav>
+    <nav class="post-nav">
+      <a class="prev" href="illinois-kolache-five-centuries-of-fi.html"
+        >← illinois-kolache-five-centuries-of-fi</a
+      >
+      <a class="back" href="../index.html">~/log</a>
+      <a class="next" href="lorem-ipsum-written-four.html">lorem-ipsum-written-four →</a>
+    </nav>
 
     <footer>
       <p class="vim-hint">← → between posts · backspace ~/log · e edit</p>

--- a/posts/lorem-ipsum-spoken-three.html
+++ b/posts/lorem-ipsum-spoken-three.html
@@ -34,11 +34,11 @@
       <div class="post-tags"></div>
     </main>
 
-      <nav class="post-nav">
-    <a class="prev" href="lorem-ipsum-written-four.html">← lorem-ipsum-written-four</a>
-    <a class="back" href="../index.html">~/log</a>
-    <a class="next" href="lorem-ipsum-written-two.html">lorem-ipsum-written-two →</a>
-  </nav>
+    <nav class="post-nav">
+      <a class="prev" href="lorem-ipsum-written-four.html">← lorem-ipsum-written-four</a>
+      <a class="back" href="../index.html">~/log</a>
+      <a class="next" href="lorem-ipsum-written-two.html">lorem-ipsum-written-two →</a>
+    </nav>
 
     <footer>
       <p class="vim-hint">← → between posts · backspace ~/log · e edit</p>

--- a/posts/lorem-ipsum-written-four.html
+++ b/posts/lorem-ipsum-written-four.html
@@ -30,11 +30,11 @@
       <div class="post-tags"></div>
     </main>
 
-      <nav class="post-nav">
-    <a class="prev" href="lorem-ipsum-spoken-five.html">← lorem-ipsum-spoken-five</a>
-    <a class="back" href="../index.html">~/log</a>
-    <a class="next" href="lorem-ipsum-spoken-three.html">lorem-ipsum-spoken-three →</a>
-  </nav>
+    <nav class="post-nav">
+      <a class="prev" href="lorem-ipsum-spoken-five.html">← lorem-ipsum-spoken-five</a>
+      <a class="back" href="../index.html">~/log</a>
+      <a class="next" href="lorem-ipsum-spoken-three.html">lorem-ipsum-spoken-three →</a>
+    </nav>
 
     <footer>
       <p class="vim-hint">← → between posts · backspace ~/log · e edit</p>


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs Prettier on `index.html` and `posts/**/*.html` whenever content is pushed directly to main
- If formatting changed, it auto-commits with `github-actions[bot]` identity
- Prevents content pushes (which bypass pre-commit hooks) from breaking CI on open PRs
- Also fixes the 4 currently unformatted files that are blocking all open PRs

## How it works
1. Content push lands on main (e.g., new blog post)
2. `auto-format.yml` triggers, runs `prettier --write` on content files only
3. If anything changed, it commits and pushes — invisible to the author
4. CI on open PRs no longer fails due to formatting drift

## Test plan
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [ ] CI passes on this PR
- [ ] After merge, verify workflow triggers on next content push

🤖 Generated with [Claude Code](https://claude.com/claude-code)