### PR TITLE
chore: upgrade claude-review to v6.2

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,4 +1,4 @@
-name: Claude PR Review
+name: Claude PR Review (Two-Stage)
 
 on:
   pull_request:
@@ -28,9 +28,46 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
-      - name: Run Claude Code
+      # ─── STAGE 0: Static Analysis ──────────────────────────────
+      # Run deterministic linters on changed files. Results are passed
+      # to Sonnet so it can focus on semantic issues, not mechanical ones.
+      - name: Static analysis (changed files)
+        id: sast
+        run: |
+          # Get list of changed files from the PR
+          CHANGED_FILES=$(gh pr diff ${{ github.event.pull_request.number || github.event.issue.number }} --name-only 2>/dev/null || echo "")
+
+          SAST_RESULTS=""
+
+          # Python: ruff (if any .py files changed and ruff is available)
+          PY_FILES=$(echo "$CHANGED_FILES" | grep '\.py$' || true)
+          if [ -n "$PY_FILES" ]; then
+            pip install ruff --quiet 2>/dev/null || true
+            if command -v ruff &>/dev/null; then
+              RUFF_OUT=$(echo "$PY_FILES" | xargs ruff check --ignore E501 2>/dev/null || true)
+              if [ -n "$RUFF_OUT" ]; then
+                SAST_RESULTS="${SAST_RESULTS}## ruff (Python linter)\n${RUFF_OUT}\n\n"
+              fi
+            fi
+          fi
+
+          # Write results to file (may be empty)
+          if [ -n "$SAST_RESULTS" ]; then
+            printf "%b" "$SAST_RESULTS" > "$RUNNER_TEMP/sast-results.txt"
+            echo "has_results=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_results=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      # ─── STAGE 1: Sonnet Review ──────────────────────────────
+      # Sonnet reads the diff, reads all touched files, and produces
+      # structured findings as JSON. This is the heavy-lifting pass.
+      - name: Sonnet Review
+        id: sonnet_review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -38,46 +75,261 @@ jobs:
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+            HEAD SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
-            You are a critical code reviewer for the vimsite project (Personal blog and engineering notebook. Conventions: TypeScript, static site generation.).
+            ## STEP 1: Load project context
+
+            CLAUDE.md is already in your system prompt. Read it again now to refresh.
+
+            Read REVIEW.md from the repository root (if it exists). This contains review-specific rules that supplement CLAUDE.md.
+
+            ## STEP 2: Get the diff
+
+            Run: `gh pr diff ${{ github.event.pull_request.number || github.event.issue.number }}`
+
+            Also read the PR title and description: `gh pr view ${{ github.event.pull_request.number || github.event.issue.number }} --json title,body --jq '.title,.body'`
+
+            ## STEP 2.5: Read touched files
+
+            For every source file modified in the diff, use the Read tool to read the full file BEFORE writing any findings. This is non-negotiable — you need the surrounding context to avoid false positives about initialization patterns, caller behavior, and function contracts. Do this now, not later.
+
+            ## STEP 2.75: Identify relevant project conventions
+
+            Before writing any findings, list the 3-5 most relevant conventions, architectural decisions, or coding standards from CLAUDE.md that apply to this diff. Write them out explicitly — these become your review criteria alongside the checklist below. If REVIEW.md exists and defines "Always Flag" or "Never Flag" rules, include those too.
+
+            ## STEP 2.8: Static analysis results
+
+            If a file exists at ${{ runner.temp }}/sast-results.txt, read it. These are deterministic linter findings on the changed files. Do NOT re-flag issues already caught by the linter — instead, incorporate them as context. If the linter found nothing (or the file doesn't exist), proceed normally.
+
+            ## STEP 3: Review
+
+            You are a critical code reviewer for this project.
 
             YOUR JOB IS TO FIND PROBLEMS, NOT SUMMARIZE. Do not describe what the code does.
 
             REVIEW CHECKLIST (in priority order):
-            1. BUGS: Logic errors, wrong math, inverted normals/winding, off-by-one, broken control flow
-            2. MAGIC NUMBERS: Every bare numeric literal (0.15, 4, 0.25, etc.) that lacks a named constant or comment explaining its origin. This is your #1 code quality check. Scan every line of the diff for unexplained numbers.
-            3. VALIDATION: Missing guards at function boundaries where bad inputs produce silent garbage (degenerate geometry, division by zero, empty collections)
-            4. INCONSISTENCIES: PR description vs actual changes, naming convention violations
+            1. BUGS: Logic errors, wrong math, off-by-one, broken control flow, violations of architecture documented in CLAUDE.md. Distinguish between:
+               - **(active)**: broken NOW in current code paths
+               - **(time bomb)**: correct today but will break when a stub/placeholder is activated
+            2. CODE QUALITY: Check the diff against the project conventions you identified in Step 2.75. Flag violations of project-documented standards — naming, structure, constants, testing patterns, build configuration, etc. This includes unexplained numeric literals that represent domain-specific values a new contributor couldn't derive from context.
+            3. ALL FILE TYPES: Review every changed file in the diff — source code, CI/CD workflows, Dockerfiles, configuration files, scripts. Do not skip non-source files.
+            4. INCONSISTENCIES: PR description vs actual changes, or internal inconsistencies within the diff itself.
 
-            Do NOT flag: style preferences, missing features (scope decisions belong in issues, not reviews), or things that work correctly as-is.
+            Do NOT flag: style preferences not documented in CLAUDE.md, missing features, or things that work correctly as-is.
 
-            OUTPUT FORMAT — Use severity tiers:
-            ### BUG (must fix before merge)
-            Real defects that cause incorrect behavior.
+            PRE-EXISTING ISSUES: If you find a bug in code not modified by this PR, flag it but mark as **(pre-existing)**.
 
-            ### MAGIC NUMBER (should fix)
-            Unexplained numeric literals. For each: state the value, the line, and ask what it represents.
+            VERIFICATION RULES (non-negotiable):
+            - Every BUG finding MUST cite the full function you read with the Read tool. If you have not read the surrounding code, do not flag it.
+            - For each BUG you draft, answer: does code outside the diff already handle this? Check callers, parent functions, and initialization patterns before including.
+            - Same-class sweep: when you find a bug pattern (e.g., "result computed but not used in verdict"), scan the rest of the diff for other instances of the same pattern before moving on.
+            - Runtime crash claims: state as "Likely bug (unverified)" with reasoning. Do not assert exceptions with certainty unless provable from pure logic.
 
-            ### SUGGESTION (nice to have)
-            Defensive improvements, documentation gaps. Clearly mark as non-blocking.
+            ## STEP 4: Return structured findings
 
-            If the code is clean, say "LGTM — no issues found." Do NOT pad with praise.
+            Return your findings as structured JSON matching the required schema. Each finding must include: the file path, line number (if applicable), severity, a short title, a description with your reasoning, and the code snippet you are citing.
 
-            RULES FOR POSTING:
-            - Use the Write tool to write your review to /tmp/review.md
-            - Post with: gh pr comment ${{ github.event.pull_request.number || github.event.issue.number }} --body-file /tmp/review.md
-            - NEVER put multi-line text in --body (causes bash permission denials)
-
-            Workflow:
-            1. Run `gh pr diff ${{ github.event.pull_request.number || github.event.issue.number }}` to read the diff
-            2. Scan EVERY numeric literal in the diff. Ask: is this explained by a constant name, comment, or obvious context (0, 1, 2 for indexing are fine)? If not, flag it.
-            3. Check for logic bugs — especially template rendering, URL handling, and build configuration
-            4. Write review to /tmp/review.md using the severity tiers above, then post with --body-file
-
-            Do NOT explore the broader codebase or run tests. Focus on the diff.
-            Do NOT use gh pr checkout — read the diff directly.
-
+            If the code is clean, return an empty findings array with summary "LGTM — no issues found."
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 15
-            --allowedTools "Write,Bash(gh pr comment *),Bash(gh pr diff *),Bash(gh pr view *),Bash(gh api *),Read,Glob,Grep"
+            --allowedTools "Bash(gh pr diff *),Bash(gh pr view *),Bash(gh api *),Read,Glob,Grep"
+            --json-schema '{"type":"object","properties":{"findings":{"type":"array","items":{"type":"object","properties":{"file":{"type":"string","description":"File path relative to repo root"},"line":{"type":"integer","description":"Line number, 0 if not applicable"},"severity":{"type":"string","enum":["BUG","CONVENTION_VIOLATION","SUGGESTION"]},"active_or_timebomb":{"type":"string","enum":["active","timebomb","na"],"description":"For BUGs only: active means broken now, timebomb means will break when stub activated"},"title":{"type":"string","description":"Short title, under 80 chars"},"description":{"type":"string","description":"Full reasoning, cite code, explain why this is a problem"},"code_snippet":{"type":"string","description":"The relevant code being cited"}},"required":["file","line","severity","title","description"]}},"summary":{"type":"string","description":"One-line summary of overall code quality"},"conventions_checked":{"type":"array","items":{"type":"string"},"description":"List of CLAUDE.md conventions identified in Step 2.75"},"files_read":{"type":"array","items":{"type":"string"},"description":"List of files read via Read tool before reviewing"}},"required":["findings","summary","conventions_checked","files_read"]}'
+
+      # ─── PRESERVE SONNET EXECUTION LOG ───────────────────────
+      - name: Preserve Sonnet execution log
+        if: always()
+        run: |
+          if [ -f "$RUNNER_TEMP/claude-execution-output.json" ]; then
+            cp "$RUNNER_TEMP/claude-execution-output.json" "$RUNNER_TEMP/sonnet-execution.json"
+          fi
+
+      # ─── SAVE SONNET OUTPUT + CHECK FINDINGS ──────────────────
+      # Write structured output to file to avoid bash interpolation issues
+      # (JSON with parentheses/quotes breaks shell parsing via ${{ }})
+      - name: Save Sonnet output
+        if: steps.sonnet_review.outputs.structured_output != ''
+        env:
+          SONNET_OUTPUT: ${{ steps.sonnet_review.outputs.structured_output }}
+        run: |
+          echo "$SONNET_OUTPUT" > "$RUNNER_TEMP/sonnet-findings.json"
+
+      - name: Check for findings
+        id: check_findings
+        if: steps.sonnet_review.outputs.structured_output != ''
+        run: |
+          FINDING_COUNT=$(jq '.findings | length' "$RUNNER_TEMP/sonnet-findings.json")
+          echo "finding_count=$FINDING_COUNT" >> $GITHUB_OUTPUT
+          if [ "$FINDING_COUNT" -eq 0 ]; then
+            echo "skip_verification=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip_verification=false" >> $GITHUB_OUTPUT
+          fi
+
+      # ─── STAGE 2: Opus Verification ──────────────────────────
+      # Opus receives Sonnet's findings and tries to DISPROVE each one.
+      # Falsification framing: default to REJECTED unless independently verified.
+      # Minimal prompt — Opus regresses with over-structured instructions.
+      - name: Opus Verification
+        id: opus_verify
+        if: |
+          steps.sonnet_review.outputs.structured_output != '' &&
+          steps.check_findings.outputs.skip_verification != 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: false
+          prompt: |
+            You are a senior code review verifier for ${{ github.repository }}, PR #${{ github.event.pull_request.number || github.event.issue.number }}.
+
+            A reviewer produced findings. Read them from the file at ${{ runner.temp }}/sonnet-findings.json using the Read tool.
+
+            Your job is to DISPROVE each finding. For each one:
+
+            1. Run `gh pr diff ${{ github.event.pull_request.number || github.event.issue.number }}` to see the actual changes.
+            2. Use the Read tool to read the cited file and surrounding context — the full function, not just the cited line.
+            3. Trace the actual execution path. Does the claimed issue really occur?
+            4. Check for guards, error handlers, or upstream validation that prevent the claimed issue.
+            5. Check if CLAUDE.md or REVIEW.md documents any conventions that explain the code (e.g., intentional pins, documented thresholds, project-specific patterns).
+            6. State your verdict: CONFIRMED or REJECTED.
+            7. Provide a one-sentence justification citing specific code.
+
+            Rules:
+            - Default to REJECTED unless you can independently verify the issue exists in the current code.
+            - Do NOT suggest fixes or improvements. Only confirm or reject.
+            - Do NOT add new findings. Your only job is verification.
+            - If the finding is technically correct but practically irrelevant (dead code path, impossible input in practice), mark REJECTED with reason.
+          claude_args: |
+            --model claude-opus-4-6
+            --max-turns 10
+            --allowedTools "Bash(gh pr diff *),Bash(gh pr view *),Read,Glob,Grep"
+            --json-schema '{"type":"object","properties":{"verifications":{"type":"array","items":{"type":"object","properties":{"original_title":{"type":"string","description":"Title from the original finding"},"verdict":{"type":"string","enum":["CONFIRMED","REJECTED"]},"reasoning":{"type":"string","description":"One-sentence justification citing specific code"},"file_read":{"type":"string","description":"File path that was read to verify"}},"required":["original_title","verdict","reasoning"]}},"confirmed_count":{"type":"integer"},"rejected_count":{"type":"integer"}},"required":["verifications","confirmed_count","rejected_count"]}'
+
+      # ─── STAGE 3: Post Consolidated Comment ──────────────────
+      - name: Post review comment
+        if: steps.sonnet_review.outputs.structured_output != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SONNET_OUTPUT: ${{ steps.sonnet_review.outputs.structured_output }}
+          OPUS_OUTPUT: ${{ steps.opus_verify.outputs.structured_output }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          SAST_HAS_RESULTS: ${{ steps.sast.outputs.has_results }}
+        run: |
+          # Write the review comment to a file to avoid bash quoting issues
+          python3 << 'PYEOF' > /tmp/review.md
+          import json, os, sys
+
+          sonnet_raw = os.environ.get("SONNET_OUTPUT", "")
+          opus_raw = os.environ.get("OPUS_OUTPUT", "")
+          head_sha = os.environ.get("HEAD_SHA", "unknown")
+          sast_has_results = os.environ.get("SAST_HAS_RESULTS", "false")
+
+          try:
+              sonnet = json.loads(sonnet_raw) if sonnet_raw else {"findings": [], "summary": "No output"}
+          except json.JSONDecodeError:
+              sonnet = {"findings": [], "summary": "Sonnet output parse error"}
+
+          findings = sonnet.get("findings", [])
+          conventions = sonnet.get("conventions_checked", [])
+
+          # If no findings, post LGTM
+          if not findings:
+              print(f"LGTM — no issues found.\n\n<!-- reviewed-at: {head_sha} -->\n<!-- model: sonnet-4.6+opus-4.6 -->\n<!-- version: v6.2 -->")
+              sys.exit(0)
+
+          # If Opus verification ran, merge verdicts
+          verdicts = {}
+          if opus_raw:
+              try:
+                  opus = json.loads(opus_raw)
+                  for v in opus.get("verifications", []):
+                      verdicts[v["original_title"]] = v
+              except json.JSONDecodeError:
+                  pass
+
+          has_opus = bool(verdicts)
+
+          # Build the comment
+          lines = ["## Code Review — Two-Stage (Sonnet + Opus)\n"]
+
+          if has_opus:
+              confirmed = sum(1 for v in verdicts.values() if v["verdict"] == "CONFIRMED")
+              rejected = sum(1 for v in verdicts.values() if v["verdict"] == "REJECTED")
+              total = len(verdicts)
+              lines.append(f"**Sonnet found {len(findings)} issues. Opus verified: {confirmed} confirmed, {rejected} rejected.**\n")
+
+          # Show conventions checked (if reported)
+          if conventions:
+              lines.append("<details><summary>Conventions checked</summary>\n")
+              for c in conventions:
+                  lines.append(f"- {c}")
+              lines.append("\n</details>\n")
+
+          # Note if SAST ran
+          if sast_has_results == "true":
+              lines.append("*Static analysis (ruff) ran on changed files. Linter findings were provided as context to the reviewer.*\n")
+
+          # Group findings by severity
+          severity_order = ["BUG", "CONVENTION_VIOLATION", "SUGGESTION"]
+          severity_labels = {
+              "BUG": "BUG (must fix before merge)",
+              "CONVENTION_VIOLATION": "CONVENTION VIOLATION (should fix)",
+              "SUGGESTION": "SUGGESTION (nice to have)",
+          }
+
+          for sev in severity_order:
+              sev_findings = [f for f in findings if f.get("severity") == sev]
+              if not sev_findings:
+                  continue
+
+              lines.append(f"### {severity_labels.get(sev, sev)}\n")
+
+              for f in sev_findings:
+                  title = f.get("title", "Untitled")
+                  desc = f.get("description", "")
+                  file_path = f.get("file", "")
+                  line_num = f.get("line", 0)
+                  snippet = f.get("code_snippet", "")
+                  active = f.get("active_or_timebomb", "na")
+
+                  # Check Opus verdict
+                  verdict_info = verdicts.get(title, {})
+                  verdict = verdict_info.get("verdict", "UNVERIFIED")
+                  verdict_reason = verdict_info.get("reasoning", "")
+
+                  if has_opus and verdict == "REJECTED":
+                      # Show rejected findings in a collapsed section
+                      lines.append(f"<details><summary>~~{title}~~ — <b>REJECTED by Opus</b></summary>\n")
+                      lines.append(f"**Sonnet said:** {desc}\n")
+                      lines.append(f"**Opus says:** {verdict_reason}\n")
+                      lines.append("</details>\n")
+                      continue
+
+                  # Active finding
+                  location = f"`{file_path}"
+                  if line_num:
+                      location += f":{line_num}"
+                  location += "`"
+
+                  badge = ""
+                  if sev == "BUG" and active in ("active", "timebomb"):
+                      badge = f" **({active})**"
+                  if has_opus and verdict == "CONFIRMED":
+                      badge += " verified"
+
+                  lines.append(f"**{title}**{badge}\n")
+                  lines.append(f"{location}\n")
+                  if snippet:
+                      lines.append(f"```\n{snippet}\n```\n")
+                  lines.append(f"{desc}\n")
+                  lines.append("---\n")
+
+          lines.append(f"\n<!-- reviewed-at: {head_sha} -->")
+          lines.append(f"<!-- model: sonnet-4.6+opus-4.6 -->")
+          lines.append(f"<!-- version: v6.2 -->")
+
+          print("\n".join(lines))
+          PYEOF
+
+          gh pr comment "$PR_NUMBER" --body-file /tmp/review.md


### PR DESCRIPTION
## Summary

- Removes MAGIC_NUMBER severity tier, replaced by CONVENTION_VIOLATION
- Adds Stage 0 SAST (static analysis on changed files before Sonnet review)
- Adds same-class sweep: when a bug pattern is found, scan the rest of the diff for other instances
- Adds all-file-types coverage: CI/CD workflows, Dockerfiles, configs are reviewed, not just source code
- Adds convention enumeration from CLAUDE.md (Step 2.75) so review criteria are explicit

## Test plan

- [ ] Open a test PR to verify the workflow triggers and completes
- [ ] Confirm Sonnet structured output parses correctly
- [ ] Confirm Opus verification stage runs when findings exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)